### PR TITLE
refactor: [anders/VIT-2445] Timestamp fixes

### DIFF
--- a/packages/vital_devices/vital_devices_ios/ios/Classes/SwiftVitalDevicesPlugin.swift
+++ b/packages/vital_devices/vital_devices_ios/ios/Classes/SwiftVitalDevicesPlugin.swift
@@ -296,6 +296,7 @@ private func mapBrandToString(_ brand: Brand) -> String {
 private func encode(_ encodable: Encodable) -> String? {
   let json: String?
   let jsonEncoder = JSONEncoder()
+  jsonEncoder.dateEncodingStrategy = .millisecondsSince1970
 
   if let data = try? encode(encodable, encoder: jsonEncoder) {
     json = String(data: data, encoding: .utf8)

--- a/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_method_channel.dart
+++ b/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_method_channel.dart
@@ -282,10 +282,8 @@ QuantitySample? _sampleFromJson(Map<dynamic, dynamic> json) {
       id: json['id'] as String?,
       value: double.parse(json['value'].toString()),
       unit: json['unit'] as String,
-      startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int,
-          isUtc: true),
-      endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int,
-          isUtc: true),
+      startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int, isUtc: true),
+      endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int, isUtc: true),
       type: json['type'] as String?,
     );
   } catch (e, stacktrace) {
@@ -294,21 +292,17 @@ QuantitySample? _sampleFromJson(Map<dynamic, dynamic> json) {
   }
 }
 
-final _swiftTimeStart = DateTime.utc(2001, 1, 1, 0, 0, 0, 0, 0);
-
 QuantitySample? _sampleFromSwiftJson(Map<dynamic, dynamic> json) {
   try {
-    final startMillisecondsSinceEpoch = (json['startDate'] as int) * 1000;
-    final endMillisecondsSinceEpoch = (json['endDate'] as int) * 1000;
+    final startMillisecondsSinceEpoch = (json['startDate'] as int);
+    final endMillisecondsSinceEpoch = (json['endDate'] as int);
 
     return QuantitySample(
       id: json['id'] as String?,
       value: double.parse(json['value'].toString()),
       unit: json['unit'] as String,
-      startDate: DateTime.fromMillisecondsSinceEpoch(
-          _swiftTimeStart.millisecondsSinceEpoch + startMillisecondsSinceEpoch),
-      endDate: DateTime.fromMillisecondsSinceEpoch(
-          _swiftTimeStart.millisecondsSinceEpoch + endMillisecondsSinceEpoch),
+      startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch, isUtc: true),
+      endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch, isUtc: true),
       type: json['type'] as String,
     );
   } catch (e, stacktrace) {

--- a/packages/vital_health/vital_health_android/lib/vital_health_android.dart
+++ b/packages/vital_health/vital_health_android/lib/vital_health_android.dart
@@ -180,7 +180,7 @@ ProcessedData _mapJsonToProcessedData(
       return ProfileProcessedData(
         biologicalSex: json['biologicalSex'],
         dateOfBirth: json['dateOfBirth'] != null
-            ? DateTime.fromMillisecondsSinceEpoch(json['dateOfBirth'])
+            ? DateTime.fromMillisecondsSinceEpoch(json['dateOfBirth'], isUtc: true)
             : null,
         heightInCm: json['heightInCm'],
       );
@@ -286,8 +286,8 @@ Sleep? _sleepFromJson(Map<dynamic, dynamic>? json) {
   }
   return Sleep(
     id: json['id'],
-    startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate']),
-    endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate']),
+    startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int, isUtc: true),
+    endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int, isUtc: true),
     sourceBundle: json['sourceBundle'],
     deviceModel: json['deviceModel'],
     heartRate: (json['heartRate'] != null
@@ -361,8 +361,8 @@ Workout? _workoutFromJson(Map<dynamic, dynamic>? json) {
   }
   return Workout(
     id: json['id'],
-    startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate']),
-    endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate']),
+    startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int, isUtc: true),
+    endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int, isUtc: true),
     sourceBundle: json['sourceBundle'],
     deviceModel: json['deviceModel'],
     sport: json['sport'],
@@ -472,10 +472,8 @@ QuantitySample? _sampleFromJson(Map<dynamic, dynamic> json) {
       id: json['id'] as String?,
       value: double.parse(json['value'].toString()),
       unit: json['unit'] as String,
-      startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int,
-          isUtc: true),
-      endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int,
-          isUtc: true),
+      startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int, isUtc: true),
+      endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int, isUtc: true),
       type: json['type'] as String?,
     );
   } catch (e, stacktrace) {

--- a/packages/vital_health/vital_health_ios/ios/Classes/Extensions/Date.swift
+++ b/packages/vital_health/vital_health_ios/ios/Classes/Extensions/Date.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Date {
+  internal init(epochMillis: Int) {
+    self.init(timeIntervalSince1970: Double(epochMillis) / 1000)
+  }
+}

--- a/packages/vital_health/vital_health_ios/ios/Classes/SwiftVitalHealthKitPlugin.swift
+++ b/packages/vital_health/vital_health_ios/ios/Classes/SwiftVitalHealthKitPlugin.swift
@@ -128,8 +128,8 @@ public class SwiftVitalHealthKitPlugin: NSObject, FlutterPlugin {
 
       let value: Double = arguments[1] as! Double
 
-      let startDate = Date(timeIntervalSince1970: Double(arguments[2] as! Int) / 1000)
-      let endDate = Date(timeIntervalSince1970: Double(arguments[3] as! Int) / 1000)
+      let startDate = Date(epochMillis: arguments[2] as! Int)
+      let endDate = Date(epochMillis: arguments[3] as! Int)
 
       let dataInput: DataInput
 
@@ -164,8 +164,8 @@ public class SwiftVitalHealthKitPlugin: NSObject, FlutterPlugin {
       let resourceString: String = arguments[0] as! String
       let resource = try mapResourceToReadableVitalResource(resourceString)
 
-      let startDate = Date(timeIntervalSince1970: Double(arguments[1] as! Int) / 1000)
-      let endDate = Date(timeIntervalSince1970: Double(arguments[2] as! Int) / 1000)
+      let startDate = Date(epochMillis: arguments[1] as! Int)
+      let endDate = Date(epochMillis: arguments[2] as! Int)
 
       NonthrowingTask {
         do {
@@ -220,6 +220,7 @@ public class SwiftVitalHealthKitPlugin: NSObject, FlutterPlugin {
         )
 
         result(nil)
+
       } catch let error {
         result(encode(ErrorResult(from: error)))
       }
@@ -523,6 +524,7 @@ private func mapProviderToVitalProvider(_ provider: String) throws -> Provider {
 private func encode(_ encodable: Encodable) -> String? {
   let json: String?
   let jsonEncoder = JSONEncoder()
+  jsonEncoder.dateEncodingStrategy = .millisecondsSince1970
 
   if let data = try? encode(encodable, encoder: jsonEncoder) {
     json = String(data: data, encoding: .utf8)

--- a/packages/vital_health/vital_health_ios/lib/vital_health_ios.dart
+++ b/packages/vital_health/vital_health_ios/lib/vital_health_ios.dart
@@ -10,8 +10,6 @@ import 'package:vital_health_platform_interface/vital_health_platform_interface.
 
 const _channel = MethodChannel('vital_health_kit');
 
-final _swiftTimeStart = DateTime.utc(2001, 1, 1, 0, 0, 0, 0, 0);
-
 class VitalHealthIos extends VitalHealthPlatform {
   static void registerWith() {
     VitalHealthPlatform.instance = VitalHealthIos();
@@ -410,15 +408,13 @@ Sleep? _sleepFromJson(Map<dynamic, dynamic>? json) {
     return null;
   }
 
-  final startMillisecondsSinceEpoch = (json['startDate'] as int) * 1000;
-  final endMillisecondsSinceEpoch = (json['endDate'] as int) * 1000;
+  final startMillisecondsSinceEpoch = (json['startDate'] as int);
+  final endMillisecondsSinceEpoch = (json['endDate'] as int);
 
   return Sleep(
     id: json['id'],
-    startDate: DateTime.fromMillisecondsSinceEpoch(
-        _swiftTimeStart.millisecondsSinceEpoch + startMillisecondsSinceEpoch),
-    endDate: DateTime.fromMillisecondsSinceEpoch(
-        _swiftTimeStart.millisecondsSinceEpoch + endMillisecondsSinceEpoch),
+    startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch, isUtc: true),
+    endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch, isUtc: true),
     sourceBundle: json['sourceBundle'],
     deviceModel: json['deviceModel'],
     heartRate: (json['heartRate'] != null
@@ -491,15 +487,13 @@ Workout? _workoutFromJson(Map<dynamic, dynamic>? json) {
     return null;
   }
 
-  final startMillisecondsSinceEpoch = (json['startDate'] as int) * 1000;
-  final endMillisecondsSinceEpoch = (json['endDate'] as int) * 1000;
+  final startMillisecondsSinceEpoch = (json['startDate'] as int);
+  final endMillisecondsSinceEpoch = (json['endDate'] as int);
 
   return Workout(
     id: json['id'],
-    startDate: DateTime.fromMillisecondsSinceEpoch(
-        _swiftTimeStart.millisecondsSinceEpoch + startMillisecondsSinceEpoch),
-    endDate: DateTime.fromMillisecondsSinceEpoch(
-        _swiftTimeStart.millisecondsSinceEpoch + endMillisecondsSinceEpoch),
+    startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch, isUtc: true),
+    endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch, isUtc: true),
     sourceBundle: json['sourceBundle'],
     deviceModel: json['deviceModel'],
     sport: json['sport'],
@@ -539,17 +533,15 @@ QuantitySample? _sampleFromSwiftJson(Map<dynamic, dynamic>? json) {
   }
 
   try {
-    final startMillisecondsSinceEpoch = (json['startDate'] as int) * 1000;
-    final endMillisecondsSinceEpoch = (json['endDate'] as int) * 1000;
+    final startMillisecondsSinceEpoch = (json['startDate'] as int);
+    final endMillisecondsSinceEpoch = (json['endDate'] as int);
 
     return QuantitySample(
       id: json['id'] as String?,
       value: double.parse(json['value'].toString()),
       unit: json['unit'] as String,
-      startDate: DateTime.fromMillisecondsSinceEpoch(
-          _swiftTimeStart.millisecondsSinceEpoch + startMillisecondsSinceEpoch),
-      endDate: DateTime.fromMillisecondsSinceEpoch(
-          _swiftTimeStart.millisecondsSinceEpoch + endMillisecondsSinceEpoch),
+      startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch, isUtc: true),
+      endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch, isUtc: true),
       type: json['type'] as String,
     );
   } catch (e, stacktrace) {


### PR DESCRIPTION
1. Use UNIX epoch in milliseconds for Swift-Dart timestamp exchange. On the Swift side, this is done via instructing `JSONEncoder` to use the `. millisecondsSince1970` date encoding strategy.

2. Audited all usage of `DateTime.fromMillisecondsSinceEpoch` — we should anchor all DateTime we serve to UTC.