### PR TITLE
VIT-2499 Fix plenty of parsing issues

### DIFF
--- a/packages/vital_health/vital_health_android/lib/vital_health_android.dart
+++ b/packages/vital_health/vital_health_android/lib/vital_health_android.dart
@@ -180,7 +180,9 @@ ProcessedData _mapJsonToProcessedData(
       return ProfileProcessedData(
         biologicalSex: json['biologicalSex'],
         dateOfBirth: json['dateOfBirth'] != null
-            ? DateTime.fromMillisecondsSinceEpoch(json['dateOfBirth'], isUtc: true)
+            ? DateTime.fromMillisecondsSinceEpoch(
+                (json['dateOfBirth'] as num).toInt(),
+                isUtc: true)
             : null,
         heightInCm: json['heightInCm'],
       );
@@ -286,8 +288,12 @@ Sleep? _sleepFromJson(Map<dynamic, dynamic>? json) {
   }
   return Sleep(
     id: json['id'],
-    startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int, isUtc: true),
-    endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int, isUtc: true),
+    startDate: DateTime.fromMillisecondsSinceEpoch(
+        (json['startDate'] as num).toInt(),
+        isUtc: true),
+    endDate: DateTime.fromMillisecondsSinceEpoch(
+        (json['endDate'] as num).toInt(),
+        isUtc: true),
     sourceBundle: json['sourceBundle'],
     deviceModel: json['deviceModel'],
     heartRate: (json['heartRate'] != null
@@ -361,8 +367,12 @@ Workout? _workoutFromJson(Map<dynamic, dynamic>? json) {
   }
   return Workout(
     id: json['id'],
-    startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int, isUtc: true),
-    endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int, isUtc: true),
+    startDate: DateTime.fromMillisecondsSinceEpoch(
+        (json['startDate'] as num).toInt(),
+        isUtc: true),
+    endDate: DateTime.fromMillisecondsSinceEpoch(
+        (json['endDate'] as num).toInt(),
+        isUtc: true),
     sourceBundle: json['sourceBundle'],
     deviceModel: json['deviceModel'],
     sport: json['sport'],
@@ -470,10 +480,14 @@ QuantitySample? _sampleFromJson(Map<dynamic, dynamic> json) {
   try {
     return QuantitySample(
       id: json['id'] as String?,
-      value: double.parse(json['value'].toString()),
+      value: (json['value'] as num).toDouble(),
       unit: json['unit'] as String,
-      startDate: DateTime.fromMillisecondsSinceEpoch(json['startDate'] as int, isUtc: true),
-      endDate: DateTime.fromMillisecondsSinceEpoch(json['endDate'] as int, isUtc: true),
+      startDate: DateTime.fromMillisecondsSinceEpoch(
+          (json['startDate'] as num).toInt(),
+          isUtc: true),
+      endDate: DateTime.fromMillisecondsSinceEpoch(
+          (json['endDate'] as num).toInt(),
+          isUtc: true),
       type: json['type'] as String?,
     );
   } catch (e, stacktrace) {

--- a/packages/vital_health/vital_health_ios/lib/vital_health_ios.dart
+++ b/packages/vital_health/vital_health_ios/lib/vital_health_ios.dart
@@ -210,7 +210,9 @@ ProcessedData _mapJsonToProcessedData(
       return ProfileProcessedData(
         biologicalSex: json['summary']["_0"]["profile"]["_0"]['biologicalSex'],
         dateOfBirth: rawDateOfBirth != null
-            ? DateTime.fromMillisecondsSinceEpoch(rawDateOfBirth, isUtc: true)
+            ? DateTime.fromMillisecondsSinceEpoch(
+                (rawDateOfBirth as num).toInt(),
+                isUtc: true)
             : null,
         heightInCm: json['summary']["_0"]["profile"]["_0"]['heightInCm'],
       );
@@ -408,13 +410,15 @@ Sleep? _sleepFromJson(Map<dynamic, dynamic>? json) {
     return null;
   }
 
-  final startMillisecondsSinceEpoch = (json['startDate'] as int);
-  final endMillisecondsSinceEpoch = (json['endDate'] as int);
+  final startMillisecondsSinceEpoch = (json['startDate'] as num).toInt();
+  final endMillisecondsSinceEpoch = (json['endDate'] as num).toInt();
 
   return Sleep(
     id: json['id'],
-    startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch, isUtc: true),
-    endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch, isUtc: true),
+    startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch,
+        isUtc: true),
+    endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch,
+        isUtc: true),
     sourceBundle: json['sourceBundle'],
     deviceModel: json['deviceModel'],
     heartRate: (json['heartRate'] != null
@@ -487,13 +491,15 @@ Workout? _workoutFromJson(Map<dynamic, dynamic>? json) {
     return null;
   }
 
-  final startMillisecondsSinceEpoch = (json['startDate'] as int);
-  final endMillisecondsSinceEpoch = (json['endDate'] as int);
+  final startMillisecondsSinceEpoch = (json['startDate'] as num).toInt();
+  final endMillisecondsSinceEpoch = (json['endDate'] as num).toInt();
 
   return Workout(
     id: json['id'],
-    startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch, isUtc: true),
-    endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch, isUtc: true),
+    startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch,
+        isUtc: true),
+    endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch,
+        isUtc: true),
     sourceBundle: json['sourceBundle'],
     deviceModel: json['deviceModel'],
     sport: json['sport'],
@@ -519,7 +525,7 @@ BloodPressureSample? _bloodPressureSampleFromSwiftJson(e) {
     return BloodPressureSample(
       systolic: _sampleFromSwiftJson(e["systolic"])!,
       diastolic: _sampleFromSwiftJson(e["diastolic"])!,
-      pulse: _sampleFromSwiftJson(e["pulse"]),
+      pulse: e["pulse"] != null ? _sampleFromSwiftJson(e["pulse"]) : null,
     );
   } catch (e, stacktrace) {
     Fimber.i("Error parsing sample: $e $stacktrace");
@@ -533,16 +539,19 @@ QuantitySample? _sampleFromSwiftJson(Map<dynamic, dynamic>? json) {
   }
 
   try {
-    final startMillisecondsSinceEpoch = (json['startDate'] as int);
-    final endMillisecondsSinceEpoch = (json['endDate'] as int);
+    final startMillisecondsSinceEpoch = (json['startDate'] as num).toInt();
+    final endMillisecondsSinceEpoch = (json['endDate'] as num).toInt();
 
     return QuantitySample(
       id: json['id'] as String?,
-      value: double.parse(json['value'].toString()),
+      value: (json['value'] as num).toDouble(),
       unit: json['unit'] as String,
-      startDate: DateTime.fromMillisecondsSinceEpoch(startMillisecondsSinceEpoch, isUtc: true),
-      endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch, isUtc: true),
-      type: json['type'] as String,
+      startDate: DateTime.fromMillisecondsSinceEpoch(
+          startMillisecondsSinceEpoch,
+          isUtc: true),
+      endDate: DateTime.fromMillisecondsSinceEpoch(endMillisecondsSinceEpoch,
+          isUtc: true),
+      type: json['type'] as String?,
     );
   } catch (e, stacktrace) {
     Fimber.i("Error parsing sample: $e $stacktrace");


### PR DESCRIPTION
* Standardise all conversions to `(jsonValue as num).toInt()` and `(jsonValue as num).toDouble()`.

   Dart JSON parser decodes JSON numbers into `int | double` depending on whether there are decimal places being present. Meanwhile, no auto conversion is offered between `int | double`. This can cause failures when extracting Swift `Date` values, which are epoch in milliseconds but not necessarily guaranteed to be an integer.

* Fixed `QuantitySample.type` extraction where `as String` was used instead of `as String?`, causing failures when a null value is present.

* Fixed `BloodPressureSample` extraction null pulse sample is not properly checked for.