### PR TITLE
[VIT-2515] Vital Devices API & example improvements

### DIFF
--- a/example/lib/device/device_bloc.dart
+++ b/example/lib/device/device_bloc.dart
@@ -56,7 +56,7 @@ class DeviceBloc extends ChangeNotifier with Disposer {
   }
 
   void pair(BuildContext context, ScannedDevice scannedDevice) {
-    _deviceManager.pair(scannedDevice).listen((event) {
+    _deviceManager.pair(scannedDevice).then((event) {
       if (event) {
         state = DeviceState.paired;
 
@@ -72,7 +72,7 @@ class DeviceBloc extends ChangeNotifier with Disposer {
       Fimber.i(error.toString(), stacktrace: stackTrace);
       ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text("Failed to pair e: $error")));
-    }).disposedBy(disposeBag);
+    });
   }
 
   void readData(BuildContext context, ScannedDevice scannedDevice) {
@@ -82,9 +82,12 @@ class DeviceBloc extends ChangeNotifier with Disposer {
     switch (scannedDevice.deviceModel.kind) {
       case DeviceKind.bloodPressure:
         // `readBloodPressureData` delivers all data in one batch, and then completes.
-        _deviceManager.readBloodPressureData(scannedDevice).listen(
+        _deviceManager.readBloodPressureData(scannedDevice).then(
             (List<BloodPressureSample> newReadings) {
           state = DeviceState.paired;
+
+          Fimber.i(
+              'Received ${newReadings.length} samples from device: ${scannedDevice.deviceModel.name}');
 
           for (var newReading in newReadings) {
             if (!bloodPressureMeterResults.any((e) =>
@@ -98,14 +101,16 @@ class DeviceBloc extends ChangeNotifier with Disposer {
 
           notifyListeners();
         },
-            onError: (error, stackTrace) => _showReadingError(
-                error, stackTrace, context)).disposedBy(disposeBag);
+            onError: (error, stackTrace) =>
+                _showReadingError(error, stackTrace, context));
         break;
       case DeviceKind.glucoseMeter:
-        // `readGlucoseMeterData` delivers all data in one batch, and then completes.
-        _deviceManager.readGlucoseMeterData(scannedDevice).listen(
+        _deviceManager.readGlucoseMeterData(scannedDevice).then(
             (List<QuantitySample> newReadings) {
           state = DeviceState.paired;
+
+          Fimber.i(
+              'Received ${newReadings.length} samples from device: ${scannedDevice.deviceModel.name}');
 
           for (var newReading in newReadings) {
             if (!glucoseMeterResults
@@ -119,8 +124,8 @@ class DeviceBloc extends ChangeNotifier with Disposer {
 
           notifyListeners();
         },
-            onError: (error, stackTrace) => _showReadingError(
-                error, stackTrace, context)).disposedBy(disposeBag);
+            onError: (error, stackTrace) =>
+                _showReadingError(error, stackTrace, context));
         break;
     }
 

--- a/packages/vital_devices/vital_devices/lib/device_manager.dart
+++ b/packages/vital_devices/vital_devices/lib/device_manager.dart
@@ -20,16 +20,16 @@ class DeviceManager {
     return VitalDevicesPlatform.instance.stopScan();
   }
 
-  Stream<bool> pair(ScannedDevice scannedDevice) {
+  Future<bool> pair(ScannedDevice scannedDevice) {
     return VitalDevicesPlatform.instance.pair(scannedDevice);
   }
 
-  Stream<List<QuantitySample>> readGlucoseMeterData(
+  Future<List<QuantitySample>> readGlucoseMeterData(
       ScannedDevice scannedDevice) {
     return VitalDevicesPlatform.instance.readGlucoseMeterData(scannedDevice);
   }
 
-  Stream<List<BloodPressureSample>> readBloodPressureData(
+  Future<List<BloodPressureSample>> readBloodPressureData(
       ScannedDevice scannedDevice) {
     return VitalDevicesPlatform.instance.readBloodPressureData(scannedDevice);
   }
@@ -38,62 +38,6 @@ class DeviceManager {
     return VitalDevicesPlatform.instance.cleanUp();
   }
 
-  final List<Brand> brands = [
-    Brand.omron,
-    Brand.accuChek,
-    Brand.contour,
-    Brand.beurer,
-    Brand.libre,
-  ];
-
-  final devices = [
-    const DeviceModel(
-      id: "omron_m4",
-      name: "Omron Intelli IT M4",
-      brand: Brand.omron,
-      kind: DeviceKind.bloodPressure,
-    ),
-    const DeviceModel(
-      id: "omron_m7",
-      name: "Omron Intelli IT M7",
-      brand: Brand.omron,
-      kind: DeviceKind.bloodPressure,
-    ),
-    const DeviceModel(
-      id: "accuchek_guide",
-      name: "Accu-Chek Guide",
-      brand: Brand.accuChek,
-      kind: DeviceKind.glucoseMeter,
-    ),
-    const DeviceModel(
-      id: "accuchek_guide_me",
-      name: "Accu-Chek Guide Me",
-      brand: Brand.accuChek,
-      kind: DeviceKind.glucoseMeter,
-    ),
-    const DeviceModel(
-      id: "accuchek_guide_active",
-      name: "Accu-Chek Active",
-      brand: Brand.accuChek,
-      kind: DeviceKind.glucoseMeter,
-    ),
-    const DeviceModel(
-      id: "contour_next_one",
-      name: "Contour Next One",
-      brand: Brand.contour,
-      kind: DeviceKind.glucoseMeter,
-    ),
-    const DeviceModel(
-      id: "beurer",
-      name: "Beurer Devices",
-      brand: Brand.beurer,
-      kind: DeviceKind.bloodPressure,
-    ),
-    const DeviceModel(
-      id: "libre1",
-      name: "Freestyle Libre 1",
-      brand: Brand.libre,
-      kind: DeviceKind.glucoseMeter,
-    ),
-  ];
+  final List<Brand> brands = VitalDevicesPlatform.instance.brands;
+  final devices = VitalDevicesPlatform.instance.devices;
 }

--- a/packages/vital_devices/vital_devices_android/android/src/main/kotlin/io/vital/VitalDevicesPlugin.kt
+++ b/packages/vital_devices/vital_devices_android/android/src/main/kotlin/io/vital/VitalDevicesPlugin.kt
@@ -96,6 +96,9 @@ class VitalDevicesPlugin : FlutterPlugin, MethodCallHandler {
                             }
                         }
                     }
+
+                    // Since the contract is delivery-once-then-complete, we assume the Dart `sendPair`
+                    // should have closed the Dart Stream/Future at this point.
                 } catch (e: Exception) {
                     withContext(Dispatchers.Main) {
                         channel.invokeMethod(
@@ -134,6 +137,9 @@ class VitalDevicesPlugin : FlutterPlugin, MethodCallHandler {
                                     )
                                 }
                             }
+
+                            // Since the contract is delivery-once-then-complete, we assume the Dart `sendGlucoseMeterReading`
+                            // should have closed the Dart Stream/Future at this point.
                     }
                 } catch (e: Exception) {
                     withContext(Dispatchers.Main) {
@@ -181,6 +187,9 @@ class VitalDevicesPlugin : FlutterPlugin, MethodCallHandler {
                                     )
                                 }
                             }
+
+                            // Since the contract is delivery-once-then-complete, we assume the Dart `sendBloodPressureReading`
+                            // should have closed the Dart Stream/Future at this point.
                     }
                 } catch (e: Exception) {
                     withContext(Dispatchers.Main) {

--- a/packages/vital_devices/vital_devices_ios/ios/Classes/SwiftVitalDevicesPlugin.swift
+++ b/packages/vital_devices/vital_devices_ios/ios/Classes/SwiftVitalDevicesPlugin.swift
@@ -182,6 +182,9 @@ public class SwiftVitalDevicesPlugin: NSObject, FlutterPlugin {
             case .failure(let error):  channel?.invokeMethod("sendPair", arguments: encode(ErrorResult(code: "PairError", message: error.localizedDescription)))
             case .finished:  channel?.invokeMethod("sendPair", arguments: encode(true))
         }
+
+        // Since the contract is delivery-once-then-complete, we assume the Dart `sendPair`
+        // should have closed the Dart Stream/Future at this point.
     }
 
     private func handlePairValue(channel: FlutterMethodChannel?) {
@@ -207,6 +210,8 @@ public class SwiftVitalDevicesPlugin: NSObject, FlutterPlugin {
                 
                 switch(value.self){
                 case .finished:
+                    // Since the contract is delivery-once-then-complete, we assume the Dart `sendGlucoseMeterReading`
+                    // should have closed the Dart Stream/Future at this point.
                     return
                 case .failure(let error):
                     self?.channel.invokeMethod("sendGlucoseMeterReading", arguments: encode(ErrorResult(code: "GlucoseMeterReadingError", message: error.localizedDescription)))
@@ -241,6 +246,8 @@ public class SwiftVitalDevicesPlugin: NSObject, FlutterPlugin {
                 
                 switch(value.self){
                 case .finished:
+                    // Since the contract is delivery-once-then-complete, we assume the Dart `sendBloodPressureReading`
+                    // should have closed the Stream/Future at this point.
                     return
                 case .failure(let error):
                     self?.channel.invokeMethod("sendBloodPressureReading", arguments: encode(ErrorResult(code: "BloodPressureReadingError", message: error.localizedDescription)))

--- a/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_method_channel.dart
+++ b/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_method_channel.dart
@@ -132,14 +132,13 @@ class VitalDevicesMethodChannel extends VitalDevicesPlatform {
   }
 
   @override
-  Stream<bool> pair(ScannedDevice scannedDevice) {
-    return Stream.fromFuture(
-      _checkPermissions().then(
-        (value) => _channel.invokeMethod('pair', [scannedDevice.id]),
-      ),
-    ).flatMap((outcome) {
+  Future<bool> pair(ScannedDevice scannedDevice) {
+    return _checkPermissions()
+        .then((value) => _channel.invokeMethod('pair', [scannedDevice.id]))
+        .then((outcome) {
       if (outcome == null) {
-        return _pairSubject;
+        // Forward either the first batch delivered, or the first error.
+        return _pairSubject.first;
       } else {
         throw UnknownException("Couldn't pair device: $outcome");
       }
@@ -147,16 +146,15 @@ class VitalDevicesMethodChannel extends VitalDevicesPlatform {
   }
 
   @override
-  Stream<List<QuantitySample>> readGlucoseMeterData(
+  Future<List<QuantitySample>> readGlucoseMeterData(
       ScannedDevice scannedDevice) {
-    return Stream.fromFuture(
-      _checkPermissions().then(
-        (value) => _channel
-            .invokeMethod('startReadingGlucoseMeter', [scannedDevice.id]),
-      ),
-    ).flatMap((outcome) {
+    return _checkPermissions()
+        .then((value) => _channel
+            .invokeMethod('startReadingGlucoseMeter', [scannedDevice.id]))
+        .then((outcome) {
       if (outcome == null) {
-        return _glucoseReadSubject;
+        // Forward either the first batch delivered, or the first error.
+        return _glucoseReadSubject.first;
       } else {
         throw UnknownException("Could not start scan: $outcome");
       }
@@ -164,16 +162,15 @@ class VitalDevicesMethodChannel extends VitalDevicesPlatform {
   }
 
   @override
-  Stream<List<BloodPressureSample>> readBloodPressureData(
+  Future<List<BloodPressureSample>> readBloodPressureData(
       ScannedDevice scannedDevice) {
-    return Stream.fromFuture(
-      _checkPermissions().then(
-        (value) => _channel
-            .invokeMethod('startReadingBloodPressure', [scannedDevice.id]),
-      ),
-    ).flatMap((outcome) {
+    return _checkPermissions()
+        .then((value) => _channel
+            .invokeMethod('startReadingBloodPressure', [scannedDevice.id]))
+        .then((outcome) {
       if (outcome == null) {
-        return _bloodPressureSubject;
+        // Forward either the first batch delivered, or the first error.
+        return _bloodPressureSubject.first;
       } else {
         throw Exception("Could not start scan: $outcome");
       }

--- a/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_platform.dart
+++ b/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_platform.dart
@@ -32,15 +32,15 @@ class VitalDevicesPlatform extends PlatformInterface {
   Future<void> stopScan() async =>
       throw UnimplementedError('stopScan() has not been implemented.');
 
-  Stream<bool> pair(ScannedDevice scannedDevice) =>
+  Future<bool> pair(ScannedDevice scannedDevice) =>
       throw UnimplementedError('pair() has not been implemented.');
 
-  Stream<List<QuantitySample>> readGlucoseMeterData(
+  Future<List<QuantitySample>> readGlucoseMeterData(
           ScannedDevice scannedDevice) =>
       throw UnimplementedError(
           'readGlucoseMeterData() has not been implemented.');
 
-  Stream<List<BloodPressureSample>> readBloodPressureData(
+  Future<List<BloodPressureSample>> readBloodPressureData(
           ScannedDevice scannedDevice) =>
       throw UnimplementedError(
           'readBloodPressureData() has not been implemented.');
@@ -77,6 +77,12 @@ class VitalDevicesPlatform extends PlatformInterface {
     const DeviceModel(
       id: "accuchek_guide_me",
       name: "Accu-Chek Guide Me",
+      brand: Brand.accuChek,
+      kind: DeviceKind.glucoseMeter,
+    ),
+    const DeviceModel(
+      id: "\$vital_ble_simulator\$",
+      name: "Vital BLE Simulator",
       brand: Brand.accuChek,
       kind: DeviceKind.glucoseMeter,
     ),


### PR DESCRIPTION
Depends on:
* Outstanding work in Android & iOS SDKs
* vital-ios package publication & dependency bump
* vital-android package publication & dependency bump


----

* Breaking API change: vital-devices now return glucose samples, blood pressure samples and pairing result all using `Future<T>`, instead of a single subscription stream.

    * This is enabled by API behaviour change in the Android and iOS SDKs, where the API now guarantees these publisher/flow always reach completion with either a full batch of samples, or an error.

    * Easier to use for API consumers, and easier to maintain for us (proxying streams of values over time correctly in a shared-nothing message sending model is way more difficult than a Future)

* Tweaked the example app, so that we stop suggesting to rescan and reread after receiving a batch of samples.

    * The old behaviour is now undesirable, since native SDKs now do stop listening and delivers the collected batch upon receipt of RACP indications, instead of infinitely listening to measurement pushes from BLE.

* Added support for Vital BLE Simulator.

* Deleted some duplicated static data.


<img src="https://user-images.githubusercontent.com/11806295/219046200-4257d75b-c4e6-4928-9480-7d21cbff4737.jpeg" width="300" />
