### PR TITLE
Adapt to recent BLE changes in native SDKs & fixes

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,16 +7,16 @@ PODS:
     - Flutter
   - vital_devices_ios (0.0.10):
     - Flutter
-    - VitalDevices (~> 0.7.16)
+    - VitalDevices (~> 0.7.17)
   - vital_health_ios (0.0.10):
     - Flutter
-    - VitalHealthKit (~> 0.7.16)
-  - VitalCore (0.7.16)
-  - VitalDevices (0.7.16):
+    - VitalHealthKit (~> 0.7.17)
+  - VitalCore (0.7.17)
+  - VitalDevices (0.7.17):
     - CombineCoreBluetooth (~> 0.3.1)
-    - VitalCore (~> 0.7.16)
-  - VitalHealthKit (0.7.16):
-    - VitalCore (~> 0.7.16)
+    - VitalCore (~> 0.7.17)
+  - VitalHealthKit (0.7.17):
+    - VitalCore (~> 0.7.17)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -48,12 +48,12 @@ SPEC CHECKSUMS:
   CombineCoreBluetooth: 87fc830440fa8b1e1024c35eaa5e116e743c2660
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
-  url_launcher_ios: fb12c43172927bb5cf75aeebd073f883801f1993
-  vital_devices_ios: e1db98856fc131a95751fa94004eaf9bc08726e4
-  vital_health_ios: 7619d765c207077d7640435e3148dfbe5d5a3f53
-  VitalCore: 467291b2406198e978135eae129a0eb6746c0c12
-  VitalDevices: 9eb80260c5b2e0852d5dc9a8778d91742199ee63
-  VitalHealthKit: 238cecd1e349221c936885bc8a294b02a554c6ee
+  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
+  vital_devices_ios: 47f65ff0431f07ccc690d5ab11d428999ff8ba1d
+  vital_health_ios: 1e1f292dac51c3eb5dca0720a78af5e1d203ad49
+  VitalCore: 87fa20d4c1c38d58dc927c5e9b90bd2dd5f70f3c
+  VitalDevices: 6976de6bfd4f8126aea00e4b1159a06b3cc4039a
+  VitalHealthKit: f52d8fa0dbdbf9bbb9d03cde6f2eb4f9b2ec3c10
 
 PODFILE CHECKSUM: c5ce1ad99de58717946d57721065d9b56b35f342
 

--- a/example/lib/device/device_screen.dart
+++ b/example/lib/device/device_screen.dart
@@ -10,7 +10,7 @@ class DeviceScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final DeviceBloc bloc = context.watch<DeviceBloc>();
-    final device = bloc.device;
+    final device = bloc.deviceModel;
 
     return Scaffold(
       appBar: AppBar(
@@ -37,6 +37,10 @@ class DeviceScreen extends StatelessWidget {
                 style: Theme.of(context).textTheme.labelLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
+              ),
+              Text(
+                bloc.deviceSource?.name ?? "",
+                style: Theme.of(context).textTheme.labelLarge,
               ),
               showResults(context, bloc),
             ],
@@ -74,7 +78,7 @@ class DeviceScreen extends StatelessWidget {
                           text: e.value.toString(),
                           style: valueTextStyle,
                           children: [
-                        TextSpan(text: " mg/dL", style: unitTextStyle)
+                        TextSpan(text: " ${e.unit}", style: unitTextStyle)
                       ])),
                   subtitle: const Divider(),
                   trailing: Column(
@@ -116,21 +120,26 @@ class DeviceScreen extends StatelessWidget {
                               text: e.systolic.value.toString(),
                               style: valueTextStyle,
                               children: [
-                            TextSpan(text: " mmHg", style: unitTextStyle)
+                            TextSpan(
+                                text: " ${e.systolic.unit}",
+                                style: unitTextStyle)
                           ])),
                       RichText(
                           text: TextSpan(
                               text: e.diastolic.value.toString(),
                               style: valueTextStyle,
                               children: [
-                            TextSpan(text: " mmHg", style: unitTextStyle)
+                            TextSpan(
+                                text: " ${e.diastolic.unit}",
+                                style: unitTextStyle)
                           ])),
                       RichText(
                           text: TextSpan(
                               text: e.pulse?.value.toString(),
                               style: valueTextStyle,
                               children: [
-                            TextSpan(text: " bpm", style: unitTextStyle)
+                            TextSpan(
+                                text: " ${e.pulse?.unit}", style: unitTextStyle)
                           ])),
                     ],
                   ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,70 +5,80 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   chopper:
     dependency: transitive
     description:
       name: chopper
-      url: "https://pub.dartlang.org"
+      sha256: "813cabd029ad8c020874429a671f2c15f45cfc3ced66b566bfa181a9b61b89b8"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.6"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   disposebag:
     dependency: "direct main"
     description:
       name: disposebag
-      url: "https://pub.dartlang.org"
+      sha256: c38be345780e0e4a4690b25b7c76b7d7d0cb39ec1c1f7895fe5e72f3630e3b78
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   fimber:
     dependency: "direct main"
     description:
       name: fimber
-      url: "https://pub.dartlang.org"
+      sha256: "1415768ddd9fd66f134dbc53f731107554c98175a63d4e93234478a113ffabb8"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.6"
   flutter:
@@ -80,7 +90,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -97,133 +108,152 @@ packages:
     dependency: transitive
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   nested:
     dependency: transitive
     description:
       name: nested
-      url: "https://pub.dartlang.org"
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   permission_handler:
     dependency: "direct main"
     description:
       name: permission_handler
-      url: "https://pub.dartlang.org"
+      sha256: "33c6a1253d1f95fd06fa74b65b7ba907ae9811f9d5c1d3150e51417d04b8d6a8"
+      url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      url: "https://pub.dartlang.org"
+      sha256: "8028362b40c4a45298f1cbfccd227c8dd6caf0e27088a69f2ba2ab15464159e2"
+      url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      url: "https://pub.dartlang.org"
+      sha256: "9c370ef6a18b1c4b2f7f35944d644a56aa23576f23abee654cf73968de93f163"
+      url: "https://pub.dev"
     source: hosted
     version: "9.0.7"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "68abbc472002b5e6dfce47fe9898c6b7d8328d58b5d2524f75e277c07a97eb84"
+      url: "https://pub.dev"
     source: hosted
     version: "3.9.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      url: "https://pub.dartlang.org"
+      sha256: f67cab14b4328574938ecea2db3475dad7af7ead6afab6338772c5f88963e38b
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.2"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      url: "https://pub.dartlang.org"
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.5"
   rxdart:
     dependency: transitive
     description:
       name: rxdart
-      url: "https://pub.dartlang.org"
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
   sky_engine:
@@ -235,177 +265,193 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   url_launcher:
     dependency: transitive
     description:
       name: url_launcher
-      url: "https://pub.dartlang.org"
+      sha256: "75f2846facd11168d007529d6cd8fcb2b750186bea046af9711f10b907e1587e"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.9"
+    version: "6.1.10"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      url: "https://pub.dartlang.org"
+      sha256: "1f4d9ebe86f333c15d318f81dcdc08b01d45da44af74552608455ebdc08d9732"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.0.23"
+    version: "6.0.24"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      url: "https://pub.dartlang.org"
+      sha256: c9cd648d2f7ab56968e049d4e9116f96a85517f1dd806b96a86ea1018a3a82e5
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.1"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      url: "https://pub.dartlang.org"
+      sha256: e29039160ab3730e42f3d811dc2a6d5f2864b90a70fb765ea60144b03307f682
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      url: "https://pub.dartlang.org"
+      sha256: "2dddb3291a57b074dade66b5e07e64401dd2487caefd4e9e2f467138d8c7eb06"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6c9ca697a5ae218ce56cece69d46128169a58aa8653c1b01d26fcd4aad8c4370"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      url: "https://pub.dartlang.org"
+      sha256: "574cfbe2390666003c3a1d129bdc4574aaa6728f0c00a4829a81c316de69dd9b"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.14"
+    version: "2.0.15"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      url: "https://pub.dartlang.org"
+      sha256: "97c9067950a0d09cbd93e2e3f0383d1403989362b97102fbf446473a48079a4b"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   vital_core:
     dependency: "direct main"
     description:
       path: "../packages/vital_core"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   vital_devices:
     dependency: "direct main"
     description:
       path: "../packages/vital_devices/vital_devices"
       relative: true
     source: path
-    version: "1.0.4"
+    version: "1.0.5"
   vital_devices_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_android"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   vital_devices_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_ios"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.1.3"
   vital_devices_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_platform_interface"
       relative: true
     source: path
-    version: "1.1.3"
+    version: "1.1.4"
   vital_health:
     dependency: "direct main"
     description:
       path: "../packages/vital_health/vital_health"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   vital_health_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_android"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   vital_health_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_ios"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   vital_health_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_platform_interface"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"
   flutter: ">=3.3.0"

--- a/packages/vital_devices/vital_devices/lib/device_manager.dart
+++ b/packages/vital_devices/vital_devices/lib/device_manager.dart
@@ -12,6 +12,10 @@ class DeviceManager {
     return devices.where((element) => element.brand == brand).toList();
   }
 
+  Future<List<ScannedDevice>> getConnectedDevices(DeviceModel deviceModel) {
+    return VitalDevicesPlatform.instance.getConnectedDevices(deviceModel);
+  }
+
   Stream<ScannedDevice> scanForDevice(DeviceModel deviceModel) {
     return VitalDevicesPlatform.instance.scanForDevice(deviceModel);
   }

--- a/packages/vital_devices/vital_devices_android/android/build.gradle
+++ b/packages/vital_devices/vital_devices_android/android/build.gradle
@@ -3,6 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.6.10'
+    ext.vital_sdk_version = '1.0.0-beta.7'
     repositories {
         google()
         mavenCentral()
@@ -51,6 +52,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
-    implementation 'com.github.tryVital.vital-android:VitalClient:v1.0.0-beta.3'
-    implementation 'com.github.tryVital.vital-android:VitalDevices:v1.0.0-beta.3'
+    implementation "com.github.tryVital.vital-android:VitalClient:$vital_sdk_version"
+    implementation "com.github.tryVital.vital-android:VitalDevices:$vital_sdk_version"
 }

--- a/packages/vital_devices/vital_devices_ios/ios/vital_devices_ios.podspec
+++ b/packages/vital_devices/vital_devices_ios/ios/vital_devices_ios.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'VitalDevices', '~> 0.7.16'
+  s.dependency 'VitalDevices', '~> 0.7.17'
   s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_method_channel.dart
+++ b/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_method_channel.dart
@@ -107,6 +107,24 @@ class VitalDevicesMethodChannel extends VitalDevicesPlatform {
   }
 
   @override
+  Future<List<ScannedDevice>> getConnectedDevices(DeviceModel deviceModel) {
+    return _channel.invokeMethod('getConnectedDevices', [
+      deviceModel.id,
+      deviceModel.name,
+      deviceModel.brand.name,
+      deviceModel.kind.name
+    ]).then((result) {
+      final error = _mapError(result);
+      if (error != null) {
+        throw error;
+      }
+
+      final jsonObjects = jsonDecode(result as String) as Iterable<dynamic>;
+      return jsonObjects.map((o) => ScannedDevice.fromMap(o)).toList();
+    });
+  }
+
+  @override
   Stream<ScannedDevice> scanForDevice(DeviceModel deviceModel) {
     return Stream.fromFuture(
       _checkPermissions().then(

--- a/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_platform.dart
+++ b/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_platform.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:vital_core/samples.dart';
 import 'package:vital_devices_platform_interface/src/brand.dart';
@@ -25,6 +27,10 @@ class VitalDevicesPlatform extends PlatformInterface {
 
   List<DeviceModel> getDevices(Brand brand) =>
       throw UnimplementedError('getDevices() has not been implemented.');
+
+  Future<List<ScannedDevice>> getConnectedDevices(DeviceModel deviceModel) =>
+      throw UnimplementedError(
+          'getConnectedDevices() has not been implemented.');
 
   Stream<ScannedDevice> scanForDevice(DeviceModel deviceModel) =>
       throw UnimplementedError('scanForDevice() has not been implemented.');
@@ -80,8 +86,8 @@ class VitalDevicesPlatform extends PlatformInterface {
       brand: Brand.accuChek,
       kind: DeviceKind.glucoseMeter,
     ),
-    const DeviceModel(
-      id: "\$vital_ble_simulator\$",
+    DeviceModel(
+      id: Platform.isIOS ? "\$vital_ble_simulator\$" : "_vital_ble_simulator_",
       name: "Vital BLE Simulator",
       brand: Brand.accuChek,
       kind: DeviceKind.glucoseMeter,

--- a/packages/vital_health/vital_health_android/android/build.gradle
+++ b/packages/vital_health/vital_health_android/android/build.gradle
@@ -3,6 +3,9 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.6.10'
+    ext.vital_sdk_version = '1.0.0-beta.7'
+    ext.health_connect_version = '1.0.0-alpha08'
+
     repositories {
         google()
         mavenCentral()
@@ -52,8 +55,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
-    implementation 'com.github.tryVital.vital-android:VitalClient:v1.0.0-beta.6'
-    implementation 'com.github.tryVital.vital-android:VitalHealthConnect:v1.0.0-beta.6'
-    implementation "androidx.health.connect:connect-client:1.0.0-alpha08"
-
+    implementation "com.github.tryVital.vital-android:VitalClient:$vital_sdk_version"
+    implementation "com.github.tryVital.vital-android:VitalHealthConnect:$vital_sdk_version"
+    implementation "androidx.health.connect:connect-client:$health_connect_version"
 }

--- a/packages/vital_health/vital_health_ios/ios/vital_health_ios.podspec
+++ b/packages/vital_health/vital_health_ios/ios/vital_health_ios.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'VitalHealthKit', '~> 0.7.16'
+  s.dependency 'VitalHealthKit', '~> 0.7.17'
   s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
* Bump to Vital iOS 0.7.17 and Vital Android 1.0.0-beta.7

* Support the new `DeviceManager.connected(DeviceModel)` API. Updated the example app to demonstrate its usage.

* Fixed decoding issue of quantity sample JSON payloads coming from Android — Dart expects a `value` JSON number; a string was passed instead.


| iOS example | Android example |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/11806295/222481669-d77899dc-11a6-49ed-9cbc-f354aa64f180.jpeg" width="300" /> | <img src="https://user-images.githubusercontent.com/11806295/222481716-77b8f6a7-3a84-46db-a55c-14267639d27d.jpeg" width="300" /> |
