### PR TITLE
[VIT-2780] Fix vital_devices pair() interop

### DIFF
--- a/packages/vital_devices/vital_devices_android/android/src/main/kotlin/io/vital/VitalDevicesPlugin.kt
+++ b/packages/vital_devices/vital_devices_android/android/src/main/kotlin/io/vital/VitalDevicesPlugin.kt
@@ -97,27 +97,16 @@ class VitalDevicesPlugin : FlutterPlugin, MethodCallHandler {
                     withContext(Dispatchers.Default) {
                         vitalDeviceManager.pair(scannedDevice).collect {
                             withContext(Dispatchers.Main) {
-                                channel.invokeMethod("sendPair", it.toString())
+                                result.success(true)
                             }
                         }
                     }
-
-                    // Since the contract is delivery-once-then-complete, we assume the Dart `sendPair`
-                    // should have closed the Dart Stream/Future at this point.
                 } catch (e: Exception) {
                     withContext(Dispatchers.Main) {
-                        channel.invokeMethod(
-                            "sendPair", JSONObject(
-                                mapOf(
-                                    "code" to "PairError",
-                                    "message" to e.message,
-                                )
-                            ).toString()
-                        )
+                        result.error("PairError", e.message, null)
                     }
                 }
             }
-            result.success(null)
         }
     }
 

--- a/packages/vital_devices/vital_devices_ios/ios/Classes/SwiftVitalDevicesPlugin.swift
+++ b/packages/vital_devices/vital_devices_ios/ios/Classes/SwiftVitalDevicesPlugin.swift
@@ -175,7 +175,12 @@ public class SwiftVitalDevicesPlugin: NSObject, FlutterPlugin {
           .pair(device: device)
           .sink { [weak self] value in
             guard self?.flutterRunning ?? false else { return }
-            result(true)
+            switch value {
+            case .finished:
+              result(true)
+            case let .failure(error):
+              result(FlutterError(code: "PairError", message: error.localizedDescription, details: nil))
+            }
           } receiveValue: { _ in }
       case .bloodPressure:
         pairCancellable = deviceManager
@@ -183,7 +188,12 @@ public class SwiftVitalDevicesPlugin: NSObject, FlutterPlugin {
           .pair(device: device)
           .sink {[weak self] value in
             guard self?.flutterRunning ?? false else { return }
-            result(true)
+            switch value {
+            case .finished:
+              result(true)
+            case let .failure(error):
+              result(FlutterError(code: "PairError", message: error.localizedDescription, details: nil))
+            }
           } receiveValue:{ _ in }
       }
     }
@@ -221,7 +231,7 @@ public class SwiftVitalDevicesPlugin: NSObject, FlutterPlugin {
                     return
                 }
                 
-                switch(value.self){
+                switch value {
                 case .finished:
                     // Since the contract is delivery-once-then-complete, we assume the Dart `sendGlucoseMeterReading`
                     // should have closed the Dart Stream/Future at this point.

--- a/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_method_channel.dart
+++ b/packages/vital_devices/vital_devices_platform_interface/lib/src/vital_devices_method_channel.dart
@@ -15,7 +15,6 @@ class VitalDevicesMethodChannel extends VitalDevicesPlatform {
   final _scanSubject = PublishSubject<ScannedDevice>();
   final _glucoseReadSubject = PublishSubject<List<QuantitySample>>();
   final _bloodPressureSubject = PublishSubject<List<BloodPressureSample>>();
-  final _pairSubject = PublishSubject<bool>();
 
   @override
   void init() {
@@ -30,22 +29,6 @@ class VitalDevicesMethodChannel extends VitalDevicesPlatform {
               _scanSubject.addError(error);
             } else {
               _scanSubject.sink.add(ScannedDevice.fromMap(decodedArguments));
-            }
-          } catch (exception, stackTrace) {
-            Fimber.i(exception.toString(), stacktrace: stackTrace);
-            _scanSubject.addError(UnknownException("$exception $stackTrace"));
-          }
-          break;
-        case "sendPair":
-          try {
-            final decodedArguments = jsonDecode(call.arguments as String);
-            final error = _mapError(decodedArguments);
-
-            if (error != null) {
-              _scanSubject.addError(error);
-            } else {
-              _pairSubject.sink
-                  .add((call.arguments as String).toLowerCase() == "true");
             }
           } catch (exception, stackTrace) {
             Fimber.i(exception.toString(), stacktrace: stackTrace);
@@ -153,14 +136,7 @@ class VitalDevicesMethodChannel extends VitalDevicesPlatform {
   Future<bool> pair(ScannedDevice scannedDevice) {
     return _checkPermissions()
         .then((value) => _channel.invokeMethod('pair', [scannedDevice.id]))
-        .then((outcome) {
-      if (outcome == null) {
-        // Forward either the first batch delivered, or the first error.
-        return _pairSubject.first;
-      } else {
-        throw UnknownException("Couldn't pair device: $outcome");
-      }
-    });
+        .then((outcome) => outcome == true);
   }
 
   @override


### PR DESCRIPTION
`VitalDevicesMethodChannel` wasn't updated for the `pair()` change to return the result directly, instead of going through a multicast stream.

Finish the adaptation. Also:

* Make sure all errors from the iOS side of `pair()` would propagate through, instead of being silently dropped.
* Expanded the example app to include `pair()` usage.