### PR TITLE
[VIT-2800] Update Android interop and improve device example

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
 android.jetifier.ignorelist = com.squareup.moshi
-android.jetifier.blacklist = com.squareup.moshi

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -9,3 +9,12 @@ localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
 def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+
+// For local development
+//includeBuild('/path/to/vital-android') {
+//    dependencySubstitution {
+//        substitute module("com.github.tryVital.vital-android:VitalClient") using project(':VitalClient')
+//        substitute module("com.github.tryVital.vital-android:VitalDevices") using project(':VitalDevices')
+//        substitute module("com.github.tryVital.vital-android:VitalHealthConnect") using project(':VitalHealthConnect')
+//    }
+//}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -395,63 +395,63 @@ packages:
       path: "../packages/vital_core"
       relative: true
     source: path
-    version: "1.2.3"
+    version: "1.5.2"
   vital_devices:
     dependency: "direct main"
     description:
       path: "../packages/vital_devices/vital_devices"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.5.2"
   vital_devices_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_android"
       relative: true
     source: path
-    version: "1.2.3"
+    version: "1.2.8"
   vital_devices_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_ios"
       relative: true
     source: path
-    version: "1.1.3"
+    version: "1.1.8"
   vital_devices_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_platform_interface"
       relative: true
     source: path
-    version: "1.1.4"
+    version: "1.1.9"
   vital_health:
     dependency: "direct main"
     description:
       path: "../packages/vital_health/vital_health"
       relative: true
     source: path
-    version: "1.2.3"
+    version: "1.5.2"
   vital_health_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_android"
       relative: true
     source: path
-    version: "1.2.3"
+    version: "1.2.8"
   vital_health_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_ios"
       relative: true
     source: path
-    version: "1.2.3"
+    version: "1.2.8"
   vital_health_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_platform_interface"
       relative: true
     source: path
-    version: "1.2.3"
+    version: "1.2.8"
 sdks:
   dart: ">=2.18.0 <4.0.0"
   flutter: ">=3.3.0"

--- a/packages/vital_devices/vital_devices_android/android/build.gradle
+++ b/packages/vital_devices/vital_devices_android/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.6.10'
-    ext.vital_sdk_version = '1.0.0-beta.7'
+    ext.vital_sdk_version = '1.0.0-beta.9'
     repositories {
         google()
         mavenCentral()
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/vital_health/vital_health_android/android/build.gradle
+++ b/packages/vital_health/vital_health_android/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.6.10'
-    ext.vital_sdk_version = '1.0.0-beta.7'
+    ext.vital_sdk_version = '1.0.0-beta.9'
     ext.health_connect_version = '1.0.0-alpha08'
 
     repositories {
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
* Updated Android SDK to 1.0.0-beta.9

* Updated Android Gradle Build Tool to 7.3.1 to match the vital-android project.

    * This is required for a integrated build-run-test workflow with vital-android via Gradle composite builds. (setup is commented out in settings.gradle)

* Updated vital_devices Kotlin interop code, which are slightly simpler now thanks to the changes upstream.

* Flutter example app now supports separated scanning and pair-n-read stages in the Device screen.

<img src="https://user-images.githubusercontent.com/11806295/230431104-40930282-614d-417a-a438-0556fb8f8e19.jpg" width="300" />
