### PR TITLE
VIT-4642: Move all vital_health method to top-level, and deprecate HealthService

### DIFF
--- a/packages/vital_core/vital_core/lib/core.dart
+++ b/packages/vital_core/vital_core/lib/core.dart
@@ -17,14 +17,14 @@ Future<void> setUserId(String userId) {
 
 Future<void> configure(String apiKey, Environment environment, Region region) {
   return VitalCorePlatform.instance
-      .configure(apiKey, environment.toString(), region.toString());
+      .configure(apiKey, environment.name, region.name);
 }
 
 Future<void> signIn(String signInToken) {
   return VitalCorePlatform.instance.signIn(signInToken);
 }
 
-Future<bool> hasUserConnectedTo(ManualProviderSlug provider) {
+Future<bool> hasUserConnectedTo(ProviderSlug provider) {
   return VitalCorePlatform.instance.hasUserConnectedTo(provider.toString());
 }
 
@@ -35,7 +35,7 @@ Future<List<VitalProvider>> userConnectedSources() {
   });
 }
 
-Future<void> createConnectedSourceIfNotExist(ProviderSlug provider) {
+Future<void> createConnectedSourceIfNotExist(ManualProviderSlug provider) {
   return VitalCorePlatform.instance
       .createConnectedSourceIfNotExist(provider.toString());
 }

--- a/packages/vital_core/vital_core/lib/provider.dart
+++ b/packages/vital_core/vital_core/lib/provider.dart
@@ -97,6 +97,16 @@ enum ProviderSlug {
   polar,
   omron;
 
+  static ProviderSlug? fromString(String rawValue) {
+    try {
+      return ProviderSlug.values
+          .firstWhere((element) => element.toString() == rawValue);
+    } catch (err) {
+      assert(err is StateError);
+      return null;
+    }
+  }
+
   @override
   String toString() {
     switch (this) {

--- a/packages/vital_core/vital_core_android/android/src/main/kotlin/io/vital/VitalCorePlugin.kt
+++ b/packages/vital_core/vital_core_android/android/src/main/kotlin/io/vital/VitalCorePlugin.kt
@@ -58,8 +58,7 @@ class VitalCorePlugin : FlutterPlugin, MethodCallHandler {
 
         when (call.method) {
             "setUserId" -> {
-                val arguments = call.arguments as? Map<*, *> ?: return reportInvalidArguments()
-                val userId = arguments["user_id"] as? String ?: return reportInvalidArguments()
+                val userId = call.arguments as? String ?: return reportInvalidArguments()
 
                 VitalClient.setUserId(context, userId)
                 result.success(null)

--- a/packages/vital_core/vital_core_platform_interface/lib/src/vital_core_method_channel.dart
+++ b/packages/vital_core/vital_core_platform_interface/lib/src/vital_core_method_channel.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:vital_core_platform_interface/vital_core_platform_interface.dart';
 
-const _channel = MethodChannel('vital_devices');
+const _channel = MethodChannel('vital_core');
 
 class VitalCoreMethodChannel extends VitalCorePlatform {
   @override

--- a/packages/vital_health/vital_health/README.md
+++ b/packages/vital_health/vital_health/README.md
@@ -26,15 +26,16 @@ The Vital SDK is split into three main components: `vital_core`, `vital_health` 
 3. To use Vital Health client you need to call configure first:
 
 ```dart
-final HealthServices healthServices = HealthServices(
-  apiKey: apiKey,
-  region: region,
-  environment: Environment.sandbox,
+import 'package:vital_core/vital_core.dart' as vital_core;
+import 'package:vital_health/vital_health.dart' as vital_health;
+
+await vital_core.configure(
+  apiKey,
+  Environment.sandbox,
+  Region.us
 );
 
-await healthServices.configureClient();
-
-await healthkServices.configureHealth(HealthConfig(
+await vital_health.configure(HealthConfig(
     iosConfig: IosHealthConfig(
       backgroundDeliveryEnabled: true,
     ),
@@ -47,13 +48,13 @@ await healthkServices.configureHealth(HealthConfig(
 4. Set User ID
 
 ```dart
-healthServices.setUserId('eba7c0a2-dc01-49f5-a361-...);
+vital_core.setUserId('eba7c0a2-dc01-49f5-a361-...);
 ```
 
 5. Ask user for permissions to collect/write Health data.
 
 ```dart
-healthServices.ask(
+vital_health.askForPermission(
   [
     HealthResource.profile,
     HealthResource.body,
@@ -69,19 +70,19 @@ healthServices.ask(
 6. Sync data
 
 ```dart
-healthServices.syncData();
+vital_health.syncData();
 ```
 
 7. Observe sync status using status stream
 
 ```dart
-Stream<SyncStatus> status = healthServices.status;
+Stream<SyncStatus> status = vital_health.status;
 ```
 
-8. When your user logs out you need to call cleanup on the health service 
+8. When your user logs out, you can call `cleanUp()` to reset the SDK state. This resets both the Vital Health and the Vital Core SDK.
     
 ```dart
-healthServices.cleanUp();
+vital_health.cleanUp();
 ```
 ## Documentation
 

--- a/packages/vital_health/vital_health/lib/health.dart
+++ b/packages/vital_health/vital_health/lib/health.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'package:vital_health_platform_interface/vital_health_platform_interface.dart';
+
+// NOTE: All methods are exposed as top-level functions, without a "VitalHealth"
+// namespace like the Native and React Native SDKs.
+//
+// > https://dart.dev/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members
+// > AVOID defining a class that contains only static members
+
+Stream<SyncStatus> get syncStatus => VitalHealthPlatform.instance.status;
+
+Future<void> configure({
+  HealthConfig config = const HealthConfig(),
+}) async {
+  await VitalHealthPlatform.instance.configureHealth(config: config);
+}
+
+Future<PermissionOutcome> askForPermission(List<HealthResource> readResources,
+    List<HealthResourceWrite> writeResources) async {
+  return VitalHealthPlatform.instance.ask(readResources, writeResources);
+}
+
+Future<bool> hasAskedForPermission(HealthResource resource) async {
+  return VitalHealthPlatform.instance.hasAskedForPermission(resource);
+}
+
+Future<void> syncData({List<HealthResource>? resources}) async {
+  await VitalHealthPlatform.instance.syncData(resources: resources);
+}
+
+Future<void> writeHealthData(HealthResourceWrite writeResource,
+    DateTime startDate, DateTime endDate, double value) async {
+  await VitalHealthPlatform.instance
+      .writeHealthData(writeResource, startDate, endDate, value);
+}
+
+Future<ProcessedData?> read(
+    HealthResource resource, DateTime startDate, DateTime endDate) {
+  return VitalHealthPlatform.instance.read(resource, startDate, endDate);
+}
+
+Future<void> cleanUp() async {
+  await VitalHealthPlatform.instance.cleanUp();
+}

--- a/packages/vital_health/vital_health/lib/health_services.dart
+++ b/packages/vital_health/vital_health/lib/health_services.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 
-import 'package:vital_core/vital_core.dart';
+import 'package:vital_core/provider.dart';
+import 'package:vital_core/vital_core.dart' as vital_core;
 import 'package:vital_health_platform_interface/vital_health_platform_interface.dart';
 
+@Deprecated("Use top-level functions in vital_health instead")
 class HealthServices {
   final String apiKey;
-  final Region region;
-  final Environment environment;
+  final vital_core.Region region;
+  final vital_core.Environment environment;
 
   HealthServices({
     required this.apiKey,
@@ -14,59 +16,74 @@ class HealthServices {
     required this.environment,
   });
 
+  @Deprecated("Use top-level `syncStatus` in vital_health instead")
   Stream<SyncStatus> get status => VitalHealthPlatform.instance.status;
 
+  @Deprecated("Import vital_core and use the top-level `configure` instead.")
   Future<void> configureClient() async {
     await VitalHealthPlatform.instance
         .configureClient(apiKey, region, environment);
   }
 
+  @Deprecated("Use top-level `configure` in vital_health instead")
   Future<void> configureHealth({
     HealthConfig config = const HealthConfig(),
   }) async {
     await VitalHealthPlatform.instance.configureHealth(config: config);
   }
 
+  @Deprecated("Import vital_core and use the top-level `setUserId` instead.")
   Future<void> setUserId(String userId) async {
-    await VitalHealthPlatform.instance.setUserId(userId);
+    await vital_core.setUserId(userId);
   }
 
   @Deprecated('Use ask() instead')
   Future<PermissionOutcome> askForResources(
       List<HealthResource> resources) async {
-    return VitalHealthPlatform.instance.askForResources(resources);
+    return await ask(resources, []);
   }
 
+  @Deprecated("Use top-level `askForPermission` in vital_health instead")
   Future<PermissionOutcome> ask(List<HealthResource> readResources,
       List<HealthResourceWrite> writeResources) async {
     return VitalHealthPlatform.instance.ask(readResources, writeResources);
   }
 
+  @Deprecated("Use top-level `hasAskedForPermission` in vital_health instead")
   Future<bool> hasAskedForPermission(HealthResource resource) async {
     return VitalHealthPlatform.instance.hasAskedForPermission(resource);
   }
 
+  @Deprecated("Use top-level `syncData` in vital_health instead")
   Future<void> syncData({List<HealthResource>? resources}) async {
     await VitalHealthPlatform.instance.syncData(resources: resources);
   }
 
   @Deprecated(
-      'Will be removed in coming versions. Use `UserService.getProviders` in the `vital_core` package instead')
+      "Import vital_core and use the top-level `hasUserConnectedTo` instead.")
   Future<bool> isUserConnected(String provider) async {
-    return VitalHealthPlatform.instance.isUserConnected(provider);
+    ProviderSlug? providerSlug = ProviderSlug.fromString(provider);
+    if (providerSlug == null) {
+      throw Exception("unrecognized provider slug: $provider");
+    }
+
+    return await vital_core.hasUserConnectedTo(providerSlug);
   }
 
+  @Deprecated("Use top-level `writeHealthData` in vital_health instead")
   Future<void> writeHealthData(HealthResourceWrite writeResource,
       DateTime startDate, DateTime endDate, double value) async {
     await VitalHealthPlatform.instance
         .writeHealthData(writeResource, startDate, endDate, value);
   }
 
+  @Deprecated("Use top-level `read` in vital_health instead")
   Future<ProcessedData?> read(
       HealthResource resource, DateTime startDate, DateTime endDate) {
     return VitalHealthPlatform.instance.read(resource, startDate, endDate);
   }
 
+  @Deprecated("Use top-level `cleanUp` in vital_health instead")
   Future<void> cleanUp() async {
     await VitalHealthPlatform.instance.cleanUp();
   }

--- a/packages/vital_health/vital_health/lib/vital_health.dart
+++ b/packages/vital_health/vital_health/lib/vital_health.dart
@@ -1,3 +1,4 @@
+export 'package:vital_health/health.dart';
 export 'package:vital_health/health_services.dart';
 export 'package:vital_health_platform_interface/src/data/health_config.dart';
 export 'package:vital_health_platform_interface/src/data/permission_outcome.dart';


### PR DESCRIPTION
Bring it in line with the new vital_core.