### PR TITLE
VIT-4679: Minimal update to Example app to demo Sign-In Token flow

### DIFF
--- a/example/lib/home/home_bloc.dart
+++ b/example/lib/home/home_bloc.dart
@@ -1,14 +1,28 @@
 import 'dart:async';
 
+import 'package:flutter/widgets.dart';
 import 'package:vital_core/services/data/user.dart';
-import 'package:vital_core/vital_core.dart';
+import 'package:vital_core/vital_core.dart' as vital_core;
 
-class HomeBloc {
-  final VitalClient client;
+class HomeBloc extends ChangeNotifier {
+  final vital_core.VitalClient client;
 
   final StreamController<List<User>> usersController = StreamController();
 
-  HomeBloc(this.client);
+  StreamSubscription? subscription;
+  String? currentUserId;
+
+  HomeBloc(this.client) {
+    subscription = vital_core.clientStatusStream.listen((status) async {
+      syncSDKState();
+    });
+    syncSDKState();
+  }
+
+  void syncSDKState() async {
+    currentUserId = await vital_core.currentUserId();
+    notifyListeners();
+  }
 
   Stream<List<User>> getUsers() {
     refresh();

--- a/example/lib/home/home_screen.dart
+++ b/example/lib/home/home_screen.dart
@@ -9,7 +9,8 @@ class UsersScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final HomeBloc bloc = Provider.of(context);
+    final HomeBloc bloc = context.watch<HomeBloc>();
+
     return Scaffold(
         appBar: AppBar(
           title: const Text('Vital SDK example app'),
@@ -52,11 +53,12 @@ class UsersPage extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 16),
               itemBuilder: ((context, index) => UserWidget(
                     user: users[index],
+                    isCurrentSDKUser: users[index].userId == bloc.currentUserId,
                     linkAction: () => bloc.launchLink(users[index]),
                     deleteAction: () => bloc.deleteUser(users[index]),
                     onTap: () {
-                      Navigator.of(context).pushNamed(Routes.user,
-                          arguments: users[index]);
+                      Navigator.of(context)
+                          .pushNamed(Routes.user, arguments: users[index]);
                     },
                   )),
               itemCount: users.length,
@@ -73,10 +75,12 @@ class UserWidget extends StatelessWidget {
   final VoidCallback? linkAction;
   final VoidCallback? deleteAction;
   final VoidCallback? onTap;
+  final bool isCurrentSDKUser;
 
   const UserWidget({
     super.key,
     required this.user,
+    required this.isCurrentSDKUser,
     this.linkAction,
     this.deleteAction,
     this.onTap,
@@ -87,43 +91,59 @@ class UserWidget extends StatelessWidget {
     return InkWell(
       onTap: onTap,
       child: Container(
-        height: 56,
         padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
-        child: Row(
-          children: [
-            const Icon(
-              Icons.person,
-              color: Colors.grey,
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                user.clientUserId ?? '',
-                style: const TextStyle(fontSize: 18.0),
-              ),
-            ),
-            if (linkAction != null) ...[
+        child: Column(children: [
+          Row(
+            children: [
+              const Icon(Icons.person, color: Colors.grey, size: 20),
               const SizedBox(width: 12),
-              IconButton(
-                onPressed: linkAction,
-                icon: const Icon(
-                  Icons.copy,
-                  color: Colors.grey,
+              Expanded(
+                child: Text(
+                  user.clientUserId ?? '',
+                  style: const TextStyle(fontSize: 18.0),
                 ),
-              )
+              ),
+              if (linkAction != null && isCurrentSDKUser) ...[
+                const SizedBox(width: 12),
+                IconButton(
+                  onPressed: linkAction,
+                  icon: const Icon(
+                    Icons.copy,
+                    color: Colors.grey,
+                  ),
+                )
+              ],
+              if (deleteAction != null) ...[
+                const SizedBox(width: 12),
+                IconButton(
+                  onPressed: deleteAction,
+                  icon: const Icon(
+                    Icons.delete,
+                    color: Colors.grey,
+                  ),
+                ),
+              ]
             ],
-            if (deleteAction != null) ...[
-              const SizedBox(width: 12),
-              IconButton(
-                onPressed: deleteAction,
-                icon: const Icon(
-                  Icons.delete,
-                  color: Colors.grey,
+          ),
+          if (isCurrentSDKUser)
+            Row(
+              children: const [
+                SizedBox(width: 32),
+                Icon(
+                  Icons.arrow_upward,
+                  color: Colors.green,
+                  size: 14,
                 ),
-              ),
-            ]
-          ],
-        ),
+                SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    "Current SDK User",
+                    style: TextStyle(fontSize: 14.0),
+                  ),
+                ),
+              ],
+            ),
+        ]),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -66,7 +66,7 @@ class VitalSampleApp extends StatelessWidget {
         ),
         initialRoute: Routes.home,
         routes: {
-          Routes.home: (_) => Provider(
+          Routes.home: (_) => ChangeNotifierProvider(
                 create: (_) => HomeBloc(
                   vitalClient,
                 ),
@@ -87,6 +87,7 @@ class VitalSampleApp extends StatelessWidget {
           Routes.user: (context) => ChangeNotifierProvider(
                 create: (_) => UserBloc(
                   ModalRoute.of(context)!.settings.arguments as User,
+                  vitalClient,
                 ),
                 child: const UserScreen(),
               ),

--- a/example/lib/user/user_screen.dart
+++ b/example/lib/user/user_screen.dart
@@ -67,72 +67,121 @@ class UserScreen extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 16),
-              Text("Health Data Sync",
-                  style: Theme.of(context).textTheme.headlineSmall),
-              ListTile(
-                title: const Text('Request the permissions for health data'),
-                trailing: OutlinedButton(
-                  onPressed: () => bloc.askForHealthResources(),
-                  child: const Text('Ask'),
-                ),
-              ),
-              ListTile(
-                title: const Text('Force sync health data'),
-                trailing: OutlinedButton(
-                  onPressed: () => bloc.sync(),
-                  child: const Text('Sync'),
-                ),
-              ),
-              ListTile(
-                title: const Text('Health sync status'),
-                subtitle: StreamBuilder(
-                  stream: bloc.status,
-                  builder: ((context, AsyncSnapshot<String> snapshot) {
-                    return Text('Status: ${snapshot.data ?? '-'}');
-                  }),
-                ),
-              ),
-              Text("Health Data Write",
-                  style: Theme.of(context).textTheme.headlineSmall),
-              ListTile(
-                title: const Text('Add water'),
-                subtitle: const Text('Add 100ml of water'),
-                trailing: OutlinedButton(
-                  onPressed: () => bloc.water(),
-                  child: const Text('Write'),
-                ),
-              ),
-              ListTile(
-                title: const Text('Add caffeine'),
-                subtitle: const Text('Add 100 mg of caffeine'),
-                trailing: OutlinedButton(
-                  onPressed: () => bloc.caffeine(),
-                  child: const Text('Write'),
-                ),
-              ),
-              ListTile(
-                title: const Text('Add mindful session'),
-                subtitle: const Text('Add 10 minutes of mindful session'),
-                trailing: OutlinedButton(
-                  onPressed: () => bloc.mindfulSession(),
-                  child: const Text('Write'),
-                ),
-              ),
-              Text("Health Data Read",
-                  style: Theme.of(context).textTheme.headlineSmall),
-              ...HealthResource.values.map((e) => ListTile(
-                    title: Text(e.name.toUpperCase()),
-                    subtitle: const Text("Print last 10 days to console"),
-                    trailing: OutlinedButton(
-                      onPressed: () => bloc.read(e),
-                      child: const Text('Read'),
-                    ),
-                  )),
-              const SizedBox(height: 60)
+              if (bloc.isCurrentSDKUser) ...currentUserWidgets(context, bloc),
+              if (!bloc.isCurrentSDKUser)
+                ...noncurrentUserWidgets(context, bloc)
             ],
           ),
         ),
       ),
     );
+  }
+
+  List<Widget> noncurrentUserWidgets(BuildContext context, UserBloc bloc) {
+    if (bloc.isSDKConfigured) {
+      return [
+        Text("SDK Status", style: Theme.of(context).textTheme.headlineSmall),
+        Text("Another user has signed-in.",
+            style: Theme.of(context).textTheme.bodyMedium),
+        ListTile(
+          title: const Text('Reset SDK'),
+          trailing: OutlinedButton(
+            onPressed: () => bloc.resetSDK(),
+            child: const Text('Reset'),
+          ),
+        ),
+      ];
+    } else {
+      return [
+        Text("SDK Status", style: Theme.of(context).textTheme.headlineSmall),
+        Text("SDK is currently unconfigured.",
+            style: Theme.of(context).textTheme.bodyMedium),
+        ListTile(
+          title: const Text('Vital Sign-In Token Demo mode'),
+          trailing: OutlinedButton(
+            onPressed: () => bloc.configureSDK(SDKAuthMode.signInTokenDemo),
+            child: const Text('Sign-in'),
+          ),
+        ),
+        ListTile(
+          title: const Text('API Key mode'),
+          trailing: OutlinedButton(
+            onPressed: () => bloc.configureSDK(SDKAuthMode.apiKey),
+            child: const Text('Sign-in'),
+          ),
+        ),
+      ];
+    }
+  }
+
+  List<Widget> currentUserWidgets(BuildContext context, UserBloc bloc) {
+    return [
+      Text("SDK Status", style: Theme.of(context).textTheme.headlineSmall),
+      Text("Signed in as current SDK user.",
+          style: Theme.of(context).textTheme.bodyMedium),
+      const SizedBox(height: 16),
+      Text("Health Data Sync",
+          style: Theme.of(context).textTheme.headlineSmall),
+      ListTile(
+        title: const Text('Request the permissions for health data'),
+        trailing: OutlinedButton(
+          onPressed: () => bloc.askForHealthResources(),
+          child: const Text('Ask'),
+        ),
+      ),
+      ListTile(
+        title: const Text('Force sync health data'),
+        trailing: OutlinedButton(
+          onPressed: () => bloc.sync(),
+          child: const Text('Sync'),
+        ),
+      ),
+      ListTile(
+        title: const Text('Health sync status'),
+        subtitle: StreamBuilder(
+          stream: bloc.healthSyncStatus,
+          builder: ((context, AsyncSnapshot<String> snapshot) {
+            return Text('Status: ${snapshot.data ?? '-'}');
+          }),
+        ),
+      ),
+      Text("Health Data Write",
+          style: Theme.of(context).textTheme.headlineSmall),
+      ListTile(
+        title: const Text('Add water'),
+        subtitle: const Text('Add 100ml of water'),
+        trailing: OutlinedButton(
+          onPressed: () => bloc.water(),
+          child: const Text('Write'),
+        ),
+      ),
+      ListTile(
+        title: const Text('Add caffeine'),
+        subtitle: const Text('Add 100 mg of caffeine'),
+        trailing: OutlinedButton(
+          onPressed: () => bloc.caffeine(),
+          child: const Text('Write'),
+        ),
+      ),
+      ListTile(
+        title: const Text('Add mindful session'),
+        subtitle: const Text('Add 10 minutes of mindful session'),
+        trailing: OutlinedButton(
+          onPressed: () => bloc.mindfulSession(),
+          child: const Text('Write'),
+        ),
+      ),
+      Text("Health Data Read",
+          style: Theme.of(context).textTheme.headlineSmall),
+      ...HealthResource.values.map((e) => ListTile(
+            title: Text(e.name.toUpperCase()),
+            subtitle: const Text("Print last 10 days to console"),
+            trailing: OutlinedButton(
+              onPressed: () => bloc.read(e),
+              child: const Text('Read'),
+            ),
+          )),
+      const SizedBox(height: 60)
+    ];
   }
 }

--- a/packages/vital_core/vital_core/lib/services/data/user.dart
+++ b/packages/vital_core/vital_core/lib/services/data/user.dart
@@ -114,6 +114,22 @@ class CreateUserResponse {
 }
 
 @JsonSerializable(createToJson: false)
+class CreateSignInTokenResponse {
+  @JsonKey(name: 'user_id')
+  String userId;
+  @JsonKey(name: 'sign_in_token')
+  String signInToken;
+
+  CreateSignInTokenResponse({
+    required this.userId,
+    required this.signInToken,
+  });
+
+  factory CreateSignInTokenResponse.fromJson(Map<String, dynamic> json) =>
+      _$CreateSignInTokenResponseFromJson(json);
+}
+
+@JsonSerializable(createToJson: false)
 class DeleteUserResponse {
   bool success;
   String? error;

--- a/packages/vital_core/vital_core/lib/services/data/user.g.dart
+++ b/packages/vital_core/vital_core/lib/services/data/user.g.dart
@@ -66,6 +66,13 @@ CreateUserResponse _$CreateUserResponseFromJson(Map<String, dynamic> json) =>
       clientUserId: json['client_user_id'] as String?,
     );
 
+CreateSignInTokenResponse _$CreateSignInTokenResponseFromJson(
+        Map<String, dynamic> json) =>
+    CreateSignInTokenResponse(
+      userId: json['user_id'] as String,
+      signInToken: json['sign_in_token'] as String,
+    );
+
 DeleteUserResponse _$DeleteUserResponseFromJson(Map<String, dynamic> json) =>
     DeleteUserResponse(
       success: json['success'] as bool? ?? false,

--- a/packages/vital_core/vital_core/lib/services/user_service.chopper.dart
+++ b/packages/vital_core/vital_core/lib/services/user_service.chopper.dart
@@ -55,6 +55,20 @@ class _$UserService extends UserService {
   }
 
   @override
+  Future<Response<CreateSignInTokenResponse>> createSignInToken(String userId) {
+    final $url = '/user/${userId}/sign_in_token';
+    final $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<CreateSignInTokenResponse, CreateSignInTokenResponse>(
+      $request,
+      requestConverter: JsonConverter.requestFactory,
+    );
+  }
+
+  @override
   Future<Response<DeleteUserResponse>> deleteUser(String userId) {
     final $url = 'user/${userId}';
     final $request = Request(

--- a/packages/vital_core/vital_core/lib/services/user_service.dart
+++ b/packages/vital_core/vital_core/lib/services/user_service.dart
@@ -27,6 +27,13 @@ abstract class UserService extends ChopperService {
   Future<Response<CreateUserResponse>> createUser(
       @Field('client_user_id') String clientUserId);
 
+  @Post(path: '/user/{user_id}/sign_in_token')
+  @FactoryConverter(
+    request: JsonConverter.requestFactory,
+  )
+  Future<Response<CreateSignInTokenResponse>> createSignInToken(
+      @Path('user_id') String userId);
+
   @Delete(path: 'user/{user_id}')
   Future<Response<DeleteUserResponse>> deleteUser(
       @Path('user_id') String userId);
@@ -65,6 +72,7 @@ abstract class UserService extends ChopperService {
           DeleteUserResponse: DeleteUserResponse.fromJson,
           DeregisterProviderResponse: DeregisterProviderResponse.fromJson,
           GetAllUsersResponse: GetAllUsersResponse.fromJson,
+          CreateSignInTokenResponse: CreateSignInTokenResponse.fromJson,
         }));
 
     return _$UserService(client);


### PR DESCRIPTION
Make some minimal changes to enable Example app to work in Vital Sign-In Token (JWT) mode, instead of the API Key mode.

* Establish the concept of "current SDK user", and hide certain UI when the user isn't the currently signed-in user (e.g., the Link button)

* Add the ability to sign-in with either Vital API Key mode, or with the Vital Sign-In Token Demo mode.

* Add the ability to reset the SDK in the UI.