### PR TITLE
VIT-4679: Add notes on sign-in token creation + a few minor Android bug fixes

### DIFF
--- a/example/lib/user/user_bloc.dart
+++ b/example/lib/user/user_bloc.dart
@@ -53,11 +53,19 @@ class UserBloc extends ChangeNotifier {
         break;
 
       case SDKAuthMode.signInTokenDemo:
+        // IMPORTANT:
+        //
+        // Calling `POST /v2/user/{id}/sign_in_token` from example app is ONLY
+        // for illustration purpose. In practice, this should be called by
+        // your backend service on behalf of your consumer apps, so that your
+        // Vital API Key is kept strictly as a server-side secret.
+        //
         CreateSignInTokenResponse response = await vitalClient.userService
             .createSignInToken(user.userId!)
             .then((resp) => resp.isSuccessful
                 ? resp.body!
                 : throw Exception("HTTP error ${resp.statusCode}"));
+
         await vital_core.signIn(response.signInToken);
         break;
     }

--- a/packages/vital_core/vital_core_android/android/src/main/kotlin/io/vital/VitalCorePlugin.kt
+++ b/packages/vital_core/vital_core_android/android/src/main/kotlin/io/vital/VitalCorePlugin.kt
@@ -38,7 +38,7 @@ class VitalCorePlugin : FlutterPlugin, MethodCallHandler {
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         taskScope = CoroutineScope(SupervisorJob())
 
-        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "vital_devices")
+        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "vital_core")
         context = flutterPluginBinding.applicationContext
         channel.setMethodCallHandler(this)
     }

--- a/packages/vital_health/vital_health_android/android/src/main/kotlin/io/vital/VitalHealthPlugin.kt
+++ b/packages/vital_health/vital_health_android/android/src/main/kotlin/io/vital/VitalHealthPlugin.kt
@@ -478,6 +478,7 @@ class VitalHealthPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
     }
 
     private fun cleanUp(result: Result) {
+        vitalHealthConnectManager.cleanUp()
         result.success(null)
     }
 


### PR DESCRIPTION
Add notes on sign-in token creation, where it is called from the example app only for illustration purpose, and that in production setup it should be done by the customer's backend so that the API Key is kept as server-side secret.
