### PR TITLE
VIT-4955: Fix Flutter Android interop exception handling

### DIFF
--- a/packages/vital_devices/vital_devices_android/android/src/main/kotlin/io/vital/VitalDevicesPlugin.kt
+++ b/packages/vital_devices/vital_devices_android/android/src/main/kotlin/io/vital/VitalDevicesPlugin.kt
@@ -191,7 +191,7 @@ class VitalDevicesPlugin : FlutterPlugin, MethodCallHandler {
                     )
                 }
             }
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             withContext(Dispatchers.Main) {
                 channel.invokeMethod(
                     "sendScan", JSONObject(
@@ -213,7 +213,7 @@ class VitalDevicesPlugin : FlutterPlugin, MethodCallHandler {
             devices.forEach { knownScannedDevices[it.address] = it }
 
             result.success(JSONArray(devices.map { it.toJsonObject() }).toString())
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             result.error("UnknownError", e.message, e)
         }
     }

--- a/packages/vital_health/vital_health_android/android/src/main/kotlin/io/vital/VitalHealthPlugin.kt
+++ b/packages/vital_health/vital_health_android/android/src/main/kotlin/io/vital/VitalHealthPlugin.kt
@@ -95,7 +95,7 @@ class VitalHealthPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                         }
                     }
                 }
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 withContext(Dispatchers.Main) {
                     channel.invokeMethod(
                         "unknown", listOf("failedSyncing")


### PR DESCRIPTION
We should be catching `Throwable` instead of `Exception`, so that all exceptions are caught and reported back to Flutter properly.

This PR fixes all instances of `catch (e: Exception)` across all packages.