### PR TITLE
VIT-4956: [Flutter] Show API error response as AlertDialog

### DIFF
--- a/example/lib/home/home_bloc.dart
+++ b/example/lib/home/home_bloc.dart
@@ -1,8 +1,16 @@
 import 'dart:async';
 
+import 'package:fimber/fimber.dart';
 import 'package:flutter/widgets.dart';
 import 'package:vital_core/services/data/user.dart';
 import 'package:vital_core/vital_core.dart' as vital_core;
+
+class UserListError {
+  final int statusCode;
+  final String message;
+
+  UserListError(this.statusCode, this.message);
+}
 
 class HomeBloc extends ChangeNotifier {
   final vital_core.VitalClient client;
@@ -31,8 +39,13 @@ class HomeBloc extends ChangeNotifier {
 
   void refresh() {
     unawaited(client.userService.getAll().then((response) {
-      if (response.body != null) {
-        usersController.sink.add(response.body!.users);
+      if (response.isSuccessful) {
+        if (response.body != null) {
+          usersController.sink.add(response.body!.users);
+        }
+      } else {
+        usersController.sink.addError(
+            UserListError(response.statusCode, response.error.toString()));
       }
     }));
   }

--- a/example/lib/home/home_screen.dart
+++ b/example/lib/home/home_screen.dart
@@ -42,6 +42,36 @@ class UsersPage extends StatelessWidget {
     return StreamBuilder(
       stream: bloc.getUsers(),
       builder: (context, AsyncSnapshot<List<User>?> snapshot) {
+        if (snapshot.error != null) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  String message;
+                  if (snapshot.error is UserListError) {
+                    UserListError error = snapshot.error as UserListError;
+                    message = "${error.statusCode}: ${error.message}";
+                  } else {
+                    message = snapshot.error.toString();
+                  }
+
+                  return AlertDialog(
+                    title: const Text("Error"),
+                    content: Text(message),
+                    actions: [
+                      TextButton(
+                        child: const Text('OK'),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                      ),
+                    ],
+                  );
+                });
+          });
+          return Container();
+        }
+
         final users = snapshot.data;
         if (users == null) {
           return const Center(child: CircularProgressIndicator.adaptive());


### PR DESCRIPTION
So that users putting incorrect API Keys have actual feedback message, instead of seeing an indefinite spinner on screen.

![Screenshot 2023-11-07 at 17 22 10](https://github.com/tryVital/vital-flutter/assets/11806295/a9c6d80b-511c-473b-8fe1-fe41156f47ce)

