### PR TITLE
VIT-5479: Add VitalClient.forSignedInUser

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,19 +7,19 @@ PODS:
     - Flutter
   - vital_core_ios (0.0.10):
     - Flutter
-    - VitalCore (~> 0.10.7)
+    - VitalCore (~> 0.10.8)
   - vital_devices_ios (0.0.10):
     - Flutter
-    - VitalDevices (~> 0.10.7)
+    - VitalDevices (~> 0.10.8)
   - vital_health_ios (0.0.10):
     - Flutter
-    - VitalHealthKit (~> 0.10.7)
-  - VitalCore (0.10.7)
-  - VitalDevices (0.10.7):
+    - VitalHealthKit (~> 0.10.8)
+  - VitalCore (0.10.8)
+  - VitalDevices (0.10.8):
     - CombineCoreBluetooth (~> 0.3.1)
-    - VitalCore (~> 0.10.7)
-  - VitalHealthKit (0.10.7):
-    - VitalCore (~> 0.10.7)
+    - VitalCore (~> 0.10.8)
+  - VitalHealthKit (0.10.8):
+    - VitalCore (~> 0.10.8)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -55,12 +55,12 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
-  vital_core_ios: 273bbc6398f89aa119970c3731966827017e511a
-  vital_devices_ios: 678ba1eed5499fd702c6daccce42c7c7c337da13
-  vital_health_ios: 96078e5e5c17babcc4e4ed2e79a85a18262618a1
-  VitalCore: fb5b9429b829748eb677cb1a2e1d851749b7ac58
-  VitalDevices: 7db473f96f8f4f76bab6f934cbcaab7692b5a3fa
-  VitalHealthKit: aaef48dc02b92dfd4bb34347e4af31a15a296c57
+  vital_core_ios: a86e15a430fb372c267d2b13a85733a106d8965f
+  vital_devices_ios: 81cb25c88556d5e730b8040a392b26ba6d2dc200
+  vital_health_ios: bff87fc526136b56cf86bf9ac99bbe0265355666
+  VitalCore: 341ef5ebdce9ab9370f33a0262c2326b92e665c3
+  VitalDevices: ca4db5a759385550c5c2132ad14a575ccc81be6d
+  VitalHealthKit: 43b400bb245fbf9a7f3b144025a6cc71a1fdfd5c
 
 PODFILE CHECKSUM: f21161b81928bd85faa21a8d8a8be5daa58b7b47
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -161,7 +161,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -227,6 +227,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/lib/user/user_screen.dart
+++ b/example/lib/user/user_screen.dart
@@ -135,6 +135,15 @@ class UserScreen extends StatelessWidget {
       Text("Signed in as current SDK user.",
           style: Theme.of(context).textTheme.bodyMedium),
       const SizedBox(height: 16),
+      Text("Vital Link", style: Theme.of(context).textTheme.headlineSmall),
+      ListTile(
+        title: const Text('Create Link Token'),
+        trailing: OutlinedButton(
+          onPressed: () => bloc.createLinkToken(),
+          child: const Text('Print to Log'),
+        ),
+      ),
+      const SizedBox(height: 16),
     ];
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -395,84 +395,84 @@ packages:
       path: "../packages/vital_core/vital_core"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_core_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_android"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_core_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_ios"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_core_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_platform_interface"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_devices:
     dependency: "direct main"
     description:
       path: "../packages/vital_devices/vital_devices"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_devices_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_android"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_devices_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_ios"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_devices_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_platform_interface"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_health:
     dependency: "direct main"
     description:
       path: "../packages/vital_health/vital_health"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_health_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_android"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_health_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_ios"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   vital_health_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_platform_interface"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.3"
   web:
     dependency: transitive
     description:

--- a/packages/vital_core/vital_core/lib/core.dart
+++ b/packages/vital_core/vital_core/lib/core.dart
@@ -66,3 +66,11 @@ Future<void> deregisterProvider(ProviderSlug provider) {
 Future<void> cleanUp() {
   return VitalCorePlatform.instance.cleanUp();
 }
+
+Future<String> getAccessToken() {
+  return VitalCorePlatform.instance.getAccessToken();
+}
+
+Future<void> refreshToken() {
+  return VitalCorePlatform.instance.refreshToken();
+}

--- a/packages/vital_core/vital_core/lib/services/activity_service.dart
+++ b/packages/vital_core/vital_core/lib/services/activity_service.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
 import 'package:vital_core/services/data/activity.dart';
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 import 'package:vital_core/services/utils/json_serializable_converter.dart';
 
@@ -41,13 +40,13 @@ abstract class ActivityService extends ChopperService {
   );
 
   static ActivityService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
       client: httpClient,
       baseUrl: baseUrl,
       interceptors: [
         HttpRequestLoggingInterceptor(),
-        HttpApiKeyInterceptor(apiKey)
+        authInterceptor,
       ],
       converter: const JsonSerializableConverter({
         ActivitiesResponse: ActivitiesResponse.fromJson,

--- a/packages/vital_core/vital_core/lib/services/body_service.dart
+++ b/packages/vital_core/vital_core/lib/services/body_service.dart
@@ -3,7 +3,6 @@ library vital;
 import 'dart:async';
 import 'package:chopper/chopper.dart';
 import 'package:vital_core/services/data/body.dart';
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 import 'package:vital_core/services/utils/json_serializable_converter.dart';
 import 'package:http/http.dart' as http;
@@ -21,13 +20,13 @@ abstract class BodyService extends ChopperService {
   );
 
   static BodyService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
       client: httpClient,
       baseUrl: baseUrl,
       interceptors: [
         HttpRequestLoggingInterceptor(),
-        HttpApiKeyInterceptor(apiKey)
+        authInterceptor,
       ],
       converter: const JsonSerializableConverter({
         BodyDataResponse: BodyDataResponse.fromJson,

--- a/packages/vital_core/vital_core/lib/services/link_service.dart
+++ b/packages/vital_core/vital_core/lib/services/link_service.dart
@@ -7,7 +7,6 @@ import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
 import 'package:vital_core/region.dart';
 import 'package:vital_core/services/data/link.dart';
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 import 'package:vital_core/services/utils/json_serializable_converter.dart';
 
@@ -81,13 +80,13 @@ abstract class LinkService extends ChopperService {
   });
 
   static LinkService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
       client: httpClient,
       baseUrl: baseUrl,
       interceptors: [
         HttpRequestLoggingInterceptor(),
-        HttpApiKeyInterceptor(apiKey)
+        authInterceptor,
       ],
       converter: const JsonSerializableConverter({
         CreateLinkResponse: CreateLinkResponse.fromJson,

--- a/packages/vital_core/vital_core/lib/services/profile_service.dart
+++ b/packages/vital_core/vital_core/lib/services/profile_service.dart
@@ -3,7 +3,6 @@ library vital;
 import 'dart:async';
 import 'package:chopper/chopper.dart';
 import 'package:vital_core/services/data/profile.dart';
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 import 'package:vital_core/services/utils/json_serializable_converter.dart';
 import 'package:http/http.dart' as http;
@@ -21,13 +20,13 @@ abstract class ProfileService extends ChopperService {
       @Path('user_id') String userId, @Query('provider') String? provider);
 
   static ProfileService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
       client: httpClient,
       baseUrl: baseUrl,
       interceptors: [
         HttpRequestLoggingInterceptor(),
-        HttpApiKeyInterceptor(apiKey)
+        authInterceptor,
       ],
       converter: const JsonSerializableConverter({
         Profile: Profile.fromJson,

--- a/packages/vital_core/vital_core/lib/services/sleep_service.dart
+++ b/packages/vital_core/vital_core/lib/services/sleep_service.dart
@@ -3,7 +3,6 @@ library vital;
 import 'dart:async';
 import 'package:chopper/chopper.dart';
 import 'package:vital_core/services/data/sleep.dart';
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 import 'package:vital_core/services/utils/json_serializable_converter.dart';
 import 'package:http/http.dart' as http;
@@ -71,13 +70,13 @@ abstract class SleepService extends ChopperService {
       @Path('sleep_id') String sleepId);
 
   static SleepService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
       client: httpClient,
       baseUrl: baseUrl,
       interceptors: [
         HttpRequestLoggingInterceptor(),
-        HttpApiKeyInterceptor(apiKey)
+        authInterceptor,
       ],
       converter: const JsonSerializableConverter({
         SleepResponse: SleepResponse.fromJson,

--- a/packages/vital_core/vital_core/lib/services/testkits_service.dart
+++ b/packages/vital_core/vital_core/lib/services/testkits_service.dart
@@ -3,7 +3,6 @@ library vital;
 import 'dart:async';
 import 'package:chopper/chopper.dart';
 import 'package:vital_core/services/data/testkits.dart';
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 import 'package:vital_core/services/utils/json_serializable_converter.dart';
 import 'package:http/http.dart' as http;
@@ -65,13 +64,13 @@ abstract class TestkitsService extends ChopperService {
   Future<Response<OrderResponse>> cancelOrder(@Path('order_id') String orderId);
 
   static TestkitsService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
         client: httpClient,
         baseUrl: baseUrl,
         interceptors: [
           HttpRequestLoggingInterceptor(),
-          HttpApiKeyInterceptor(apiKey)
+          authInterceptor,
         ],
         converter: const JsonSerializableConverter({
           OrdersResponse: OrdersResponse.fromJson,

--- a/packages/vital_core/vital_core/lib/services/user_service.dart
+++ b/packages/vital_core/vital_core/lib/services/user_service.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 
 import 'data/user.dart';
@@ -56,13 +55,13 @@ abstract class UserService extends ChopperService {
   Future<Response<RefreshResponse>> refreshUser(@Path('user_id') String userId);
 
   static UserService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
         client: httpClient,
         baseUrl: baseUrl,
         interceptors: [
           HttpRequestLoggingInterceptor(),
-          HttpApiKeyInterceptor(apiKey)
+          authInterceptor,
         ],
         converter: const JsonSerializableConverter({
           User: User.fromJson,

--- a/packages/vital_core/vital_core/lib/services/utils/http_api_key_interceptor.dart
+++ b/packages/vital_core/vital_core/lib/services/utils/http_api_key_interceptor.dart
@@ -1,5 +1,0 @@
-import 'package:chopper/chopper.dart';
-
-class HttpApiKeyInterceptor extends HeadersInterceptor {
-  HttpApiKeyInterceptor(String apiKey) : super({"x-vital-api-key": apiKey});
-}

--- a/packages/vital_core/vital_core/lib/services/utils/vital_interceptor.dart
+++ b/packages/vital_core/vital_core/lib/services/utils/vital_interceptor.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:chopper/chopper.dart';
+import 'package:vital_core/core.dart' as vital_core;
+
+class VitalInterceptor extends HeadersInterceptor {
+  final String? apiKey;
+  final bool useAccessToken;
+
+  VitalInterceptor(this.useAccessToken, this.apiKey) : super({}) {
+    if (useAccessToken && apiKey != null) {
+      throw Exception("useAccessToken is true, but an API key is provided.");
+    }
+
+    if (!useAccessToken && apiKey == null) {
+      throw Exception(
+          "useAccessToken is false, but an API key is not provided.");
+    }
+  }
+
+  @override
+  Future<Request> onRequest(Request request) async {
+    String versionKey, versionValue, authKey, authValue;
+
+    if (Platform.isIOS) {
+      versionKey = "X-Vital-iOS-SDK-Version";
+      versionValue = "0.10.8";
+    } else if (Platform.isAndroid) {
+      versionKey = "X-Vital-Android-SDK-Version";
+      versionValue = "1.0.0-beta.23";
+    } else {
+      throw Exception("Unsupported Flutter platform");
+    }
+
+    if (useAccessToken) {
+      String accessToken = await vital_core.getAccessToken();
+      authKey = "Authorization";
+      authValue = "Bearer $accessToken";
+    } else {
+      authKey = "X-Vital-API-Key";
+      authValue = apiKey!;
+    }
+
+    return applyHeaders(request, {
+      authKey: authValue,
+      versionKey: versionValue,
+    });
+  }
+}

--- a/packages/vital_core/vital_core/lib/services/utils/vital_interceptor.dart
+++ b/packages/vital_core/vital_core/lib/services/utils/vital_interceptor.dart
@@ -23,14 +23,15 @@ class VitalInterceptor extends HeadersInterceptor {
   Future<Request> onRequest(Request request) async {
     String versionKey, versionValue, authKey, authValue;
 
-    if (Platform.isIOS) {
+    if (Platform.isIOS || Platform.isMacOS) {
       versionKey = "X-Vital-iOS-SDK-Version";
       versionValue = "0.10.8";
-    } else if (Platform.isAndroid) {
+    } else if (Platform.isAndroid || Platform.isLinux) {
       versionKey = "X-Vital-Android-SDK-Version";
       versionValue = "1.0.0-beta.23";
     } else {
-      throw Exception("Unsupported Flutter platform");
+      throw Exception(
+          "Unsupported Flutter platform: ${Platform.operatingSystem}");
     }
 
     if (useAccessToken) {

--- a/packages/vital_core/vital_core/lib/services/vitals_service.dart
+++ b/packages/vital_core/vital_core/lib/services/vitals_service.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 import 'package:vital_core/services/utils/json_serializable_converter.dart';
 
@@ -188,13 +187,13 @@ abstract class VitalsService extends ChopperService {
   }
 
   static VitalsService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
         client: httpClient,
         baseUrl: baseUrl,
         interceptors: [
           HttpRequestLoggingInterceptor(),
-          HttpApiKeyInterceptor(apiKey)
+          authInterceptor,
         ],
         converter: const JsonSerializableConverter({
           Measurement: Measurement.fromJson,

--- a/packages/vital_core/vital_core/lib/services/workout_service.dart
+++ b/packages/vital_core/vital_core/lib/services/workout_service.dart
@@ -3,7 +3,6 @@ library vital;
 import 'dart:async';
 import 'package:chopper/chopper.dart';
 import 'package:vital_core/services/data/workout.dart';
-import 'package:vital_core/services/utils/http_api_key_interceptor.dart';
 import 'package:vital_core/services/utils/http_logging_interceptor.dart';
 import 'package:vital_core/services/utils/json_serializable_converter.dart';
 import 'package:http/http.dart' as http;
@@ -34,13 +33,13 @@ abstract class WorkoutService extends ChopperService {
   );
 
   static WorkoutService create(
-      http.Client httpClient, Uri baseUrl, String apiKey) {
+      http.Client httpClient, Uri baseUrl, RequestInterceptor authInterceptor) {
     final client = ChopperClient(
         client: httpClient,
         baseUrl: baseUrl,
         interceptors: [
           HttpRequestLoggingInterceptor(),
-          HttpApiKeyInterceptor(apiKey)
+          authInterceptor,
         ],
         converter: const JsonSerializableConverter({
           WorkoutsResponse: WorkoutsResponse.fromJson,

--- a/packages/vital_core/vital_core/test/services/activity_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/activity_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:vital_core/services/activity_service.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -13,7 +14,7 @@ void main() {
   group('Activity service', () {
     test('Get activities', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/summary/activity/user_id_1'));
+        expect(req.url.toString(), contains('/summary/activity/user_id_1'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         expect(req.url.queryParameters['start_date'], startsWith('2022-07-01'));
@@ -25,7 +26,8 @@ void main() {
         );
       });
 
-      final sut = ActivityService.create(httpClient, '', apiKey);
+      final sut = ActivityService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getActivity(userId,
           DateTime.parse('2022-07-01'), DateTime.parse('2022-07-21'), null);
 

--- a/packages/vital_core/vital_core/test/services/body_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/body_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:vital_core/services/body_service.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -13,7 +14,7 @@ void main() {
   group('Body service', () {
     test('Get body data', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/summary/body/user_id_1'));
+        expect(req.url.toString(), contains('/summary/body/user_id_1'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         expect(req.url.queryParameters['start_date'], startsWith('2022-07-01'));
@@ -25,7 +26,8 @@ void main() {
         );
       });
 
-      final sut = BodyService.create(httpClient, '', apiKey);
+      final sut = BodyService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getBodyData(userId,
           DateTime.parse('2022-07-01'), DateTime.parse('2022-07-21'), null);
 

--- a/packages/vital_core/vital_core/test/services/link_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/link_service_test.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:vital_core/region.dart';
 import 'package:vital_core/services/link_service.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -16,7 +17,8 @@ void main() {
       final httpClient =
           linkClient('POST', '/link/token', fakeCreateLinkResponse);
 
-      final sut = LinkService.create(httpClient, '', apiKey);
+      final sut = LinkService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response =
           await sut.createLink(userId, 'strava', 'callback://vital');
 
@@ -28,7 +30,8 @@ void main() {
       final httpClient = linkClient(
           'GET', '/link/provider/oauth/strava', fakeLinkOauthProviderResponse);
 
-      final sut = LinkService.create(httpClient, '', apiKey);
+      final sut = LinkService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.oauthProvider(
         provider: 'strava',
         linkToken: linkToken,
@@ -45,7 +48,8 @@ void main() {
       final httpClient = linkClient(
           'POST', '/link/provider/email/strava', fakeEmailLinkResponse);
 
-      final sut = LinkService.create(httpClient, '', apiKey);
+      final sut = LinkService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.emailProvider(
         provider: 'strava',
         email: 'test@test.com',
@@ -62,7 +66,8 @@ void main() {
       final httpClient = linkClient(
           'POST', '/link/provider/password/strava', fakeEmailLinkResponse);
 
-      final sut = LinkService.create(httpClient, '', apiKey);
+      final sut = LinkService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.passwordProvider(
         provider: 'strava',
         username: 'username',
@@ -80,7 +85,7 @@ void main() {
 
 MockClient linkClient(String method, String path, String response) {
   return MockClient((http.Request req) async {
-    expect(req.url.toString(), path);
+    expect(req.url.toString(), contains(path));
     expect(req.method, method);
     expect(req.headers['x-vital-api-key'], apiKey);
     return http.Response(

--- a/packages/vital_core/vital_core/test/services/profile_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/profile_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:vital_core/services/profile_service.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -14,7 +15,8 @@ void main() {
     test('Get profile', () async {
       final httpClient = profileClient(fakeProfileResponse);
 
-      final sut = ProfileService.create(httpClient, '', apiKey);
+      final sut = ProfileService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getProfile(userId, null);
 
       final profile = response.body!;
@@ -28,7 +30,8 @@ void main() {
     test('Get profile nulls', () async {
       final httpClient = profileClient(fakeProfileResponseNulls);
 
-      final sut = ProfileService.create(httpClient, '', apiKey);
+      final sut = ProfileService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getProfile(userId, null);
 
       final profile = response.body!;
@@ -42,7 +45,7 @@ void main() {
 
 MockClient profileClient(String response) {
   return MockClient((http.Request req) async {
-    expect(req.url.toString(), '/summary/profile/user_id_1');
+    expect(req.url.toString(), contains('/summary/profile/user_id_1'));
     expect(req.method, 'GET');
     expect(req.headers['x-vital-api-key'], apiKey);
     return http.Response(

--- a/packages/vital_core/vital_core/test/services/sleep_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/sleep_service_test.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:vital_core/services/data/sleep.dart';
 import 'package:vital_core/services/sleep_service.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -17,7 +18,8 @@ void main() {
           '/summary/sleep/user_id_1', fakeSleepDataResponse,
           validation: validateDateRange);
 
-      final sut = SleepService.create(httpClient, '', apiKey);
+      final sut = SleepService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getSleepData(userId,
           DateTime.parse('2022-07-01'), DateTime.parse('2022-07-21'), null);
 
@@ -31,7 +33,8 @@ void main() {
           '/summary/sleep/user_id_1/stream', fakeSleepStreamSeriesResponse,
           validation: validateDateRange);
 
-      final sut = SleepService.create(httpClient, '', apiKey);
+      final sut = SleepService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getSleepStreamSeries(userId,
           DateTime.parse('2022-07-01'), DateTime.parse('2022-07-21'), null);
 
@@ -46,7 +49,8 @@ void main() {
       final httpClient = sleepClient(
           '/timeseries/sleep/stream_id_1/stream', fakeSleepStreamResponse);
 
-      final sut = SleepService.create(httpClient, '', apiKey);
+      final sut = SleepService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getSleepStream(streamId);
 
       final sleepStream = response.body!;
@@ -58,7 +62,7 @@ void main() {
 MockClient sleepClient(String path, String response,
     {Function(http.Request)? validation}) {
   return MockClient((http.Request req) async {
-    expect(req.url.toString(), startsWith(path));
+    expect(req.url.toString(), contains(path));
     expect(req.method, 'GET');
     validation?.call(req);
     expect(req.headers['x-vital-api-key'], apiKey);

--- a/packages/vital_core/vital_core/test/services/testkits_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/testkits_service_test.dart
@@ -5,6 +5,7 @@ import 'package:vital_core/services/data/testkits.dart';
 import 'package:vital_core/services/testkits_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -16,7 +17,7 @@ void main() {
   group('Testkits service', () {
     test('Get all orders', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/testkit/orders'));
+        expect(req.url.toString(), contains('/testkit/orders'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         expect(req.url.queryParameters['start_date'], startsWith('2022-07-01'));
@@ -28,7 +29,8 @@ void main() {
         );
       });
 
-      final sut = TestkitsService.create(httpClient, '', apiKey);
+      final sut = TestkitsService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getAllOrders(
           DateTime.parse('2022-07-01'), DateTime.parse('2022-07-21'), null);
 
@@ -39,7 +41,7 @@ void main() {
 
     test('Get all testkits', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/testkit/'));
+        expect(req.url.toString(), contains('/testkit/'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -49,7 +51,8 @@ void main() {
         );
       });
 
-      final sut = TestkitsService.create(httpClient, '', apiKey);
+      final sut = TestkitsService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getAllTestkits();
 
       expect(response.body!.testkits.length, 2);
@@ -63,7 +66,7 @@ void main() {
 
     test('Create order', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), '/testkit/orders');
+        expect(req.url.toString(), contains('/testkit/orders'));
         expect(req.method, 'POST');
         expect(req.headers['x-vital-api-key'], apiKey);
         final request = CreateOrderRequest.fromJson(json.decode(req.body));
@@ -79,7 +82,8 @@ void main() {
         );
       });
 
-      final sut = TestkitsService.create(httpClient, '', apiKey);
+      final sut = TestkitsService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.createOrder(
           CreateOrderRequest(
             testkitId: '71d54fff-70e1-4f74-937e-5a185b925d0d',
@@ -108,7 +112,7 @@ void main() {
 
     test('Cancel order', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), '/testkit/orders/id_1/cancel');
+        expect(req.url.toString(), contains('/testkit/orders/id_1/cancel'));
         expect(req.method, 'POST');
         expect(req.headers['x-vital-api-key'], apiKey);
 
@@ -119,7 +123,8 @@ void main() {
         );
       });
 
-      final sut = TestkitsService.create(httpClient, '', apiKey);
+      final sut = TestkitsService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.cancelOrder('id_1');
 
       expect(response.body!.status, 'success');

--- a/packages/vital_core/vital_core/test/services/user_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/user_service_test.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:vital_core/services/data/user.dart';
 import 'package:vital_core/services/user_service.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -14,7 +15,7 @@ void main() {
   group('User service', () {
     test('Get all users', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/user/'));
+        expect(req.url.toString(), contains('/user/'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -24,7 +25,8 @@ void main() {
         );
       });
 
-      final sut = UserService.create(httpClient, '', apiKey);
+      final sut = UserService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getAll();
       final users = response.body!.users;
       expect(users.length, 2);
@@ -36,7 +38,7 @@ void main() {
 
     test('Get user', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/user/$userId'));
+        expect(req.url.toString(), contains('/user/$userId'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -46,14 +48,15 @@ void main() {
         );
       });
 
-      final sut = UserService.create(httpClient, '', apiKey);
+      final sut = UserService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getUser(userId);
       validateFirstUser(response.body!);
     });
 
     test('Resolve user', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/user/key/User%20Name'));
+        expect(req.url.toString(), contains('/user/key/User%20Name'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -63,14 +66,15 @@ void main() {
         );
       });
 
-      final sut = UserService.create(httpClient, '', apiKey);
+      final sut = UserService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.resolveUser(userName);
       validateFirstUser(response.body!);
     });
 
     test('Get providers', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/user/providers/$userId'));
+        expect(req.url.toString(), contains('/user/providers/$userId'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -80,7 +84,8 @@ void main() {
         );
       });
 
-      final sut = UserService.create(httpClient, '', apiKey);
+      final sut = UserService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getProviders(userId);
       final provider = response.body!.providers[0];
       expect(provider.name, 'Fitbit');
@@ -89,7 +94,7 @@ void main() {
 
     test('Get refresh user', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/user/refresh/$userId'));
+        expect(req.url.toString(), contains('/user/refresh/$userId'));
         expect(req.method, 'POST');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -99,7 +104,8 @@ void main() {
         );
       });
 
-      final sut = UserService.create(httpClient, '', apiKey);
+      final sut = UserService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.refreshUser(userId);
       expect(response.body!.refreshedSources.length, 5);
       expect(response.body!.failedSources.length, 3);
@@ -107,7 +113,7 @@ void main() {
 
     test('Create user', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/user/key'));
+        expect(req.url.toString(), contains('/user/key'));
         expect(req.method, 'POST');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -117,7 +123,8 @@ void main() {
         );
       });
 
-      final sut = UserService.create(httpClient, '', apiKey);
+      final sut = UserService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.createUser(userName);
       final user = response.body!;
       expect(user.userId, userId);
@@ -127,7 +134,7 @@ void main() {
 
     test('Delete user', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/user/$userId'));
+        expect(req.url.toString(), contains('/user/$userId'));
         expect(req.method, 'DELETE');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -137,14 +144,15 @@ void main() {
         );
       });
 
-      final sut = UserService.create(httpClient, '', apiKey);
+      final sut = UserService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.deleteUser(userId);
       expect(response.body!.success, true);
     });
 
     test('Deregister provider', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/user/$userId/strava'));
+        expect(req.url.toString(), contains('/user/$userId/strava'));
         expect(req.method, 'DELETE');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -154,7 +162,8 @@ void main() {
         );
       });
 
-      final sut = UserService.create(httpClient, '', apiKey);
+      final sut = UserService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.deregisterProvider(userId, 'strava');
       expect(response.body!.success, true);
     });

--- a/packages/vital_core/vital_core/test/services/vitals_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/vitals_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:vital_core/services/data/vitals.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 import 'package:vital_core/services/vitals_service.dart';
 
 void main() {
@@ -17,7 +18,8 @@ void main() {
         final httpClient =
             createVitalsClient('/timeseries/$userId/cholesterol/${type.name}');
 
-        final sut = VitalsService.create(httpClient, '', apiKey);
+        final sut = VitalsService.create(httpClient,
+            Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
         final response = await sut.getCholesterol(
           type,
           userId,
@@ -31,7 +33,8 @@ void main() {
     test('Get glucose', () async {
       final httpClient = createVitalsClient('/timeseries/$userId/glucose');
 
-      final sut = VitalsService.create(httpClient, '', apiKey);
+      final sut = VitalsService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getGlucose(
         userId,
         DateTime.parse('2022-07-01'),
@@ -44,7 +47,7 @@ void main() {
 
 MockClient createVitalsClient(String path) {
   return MockClient((http.Request req) async {
-    expect(req.url.toString(), startsWith(path));
+    expect(req.url.toString(), contains(path));
     expect(req.method, 'GET');
     expect(req.headers['x-vital-api-key'], apiKey);
     expect(req.url.queryParameters['start_date'], startsWith('2022-07-01'));

--- a/packages/vital_core/vital_core/test/services/workout_service_test.dart
+++ b/packages/vital_core/vital_core/test/services/workout_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:vital_core/services/utils/vital_interceptor.dart';
 import 'package:vital_core/services/workout_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -13,7 +14,7 @@ void main() {
   group('Workouts service', () {
     test('Get workouts', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), startsWith('/summary/workouts/user_id_1'));
+        expect(req.url.toString(), contains('/summary/workouts/user_id_1'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         expect(req.url.queryParameters['start_date'], startsWith('2022-07-01'));
@@ -25,7 +26,8 @@ void main() {
         );
       });
 
-      final sut = WorkoutService.create(httpClient, '', apiKey);
+      final sut = WorkoutService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getWorkouts(
         userId,
         DateTime.parse('2022-07-01'),
@@ -44,7 +46,8 @@ void main() {
 
     test('Get workout stream', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), '/timeseries/workouts/$workoutId/stream');
+        expect(req.url.toString(),
+            contains('/timeseries/workouts/$workoutId/stream'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -54,7 +57,8 @@ void main() {
         );
       });
 
-      final sut = WorkoutService.create(httpClient, '', apiKey);
+      final sut = WorkoutService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getWorkoutStream(workoutId);
       final stream = response.body!;
       expect(stream.lat[0], 12.123456);
@@ -69,7 +73,8 @@ void main() {
 
     test('Get workout stream nulls', () async {
       final httpClient = MockClient((http.Request req) async {
-        expect(req.url.toString(), '/timeseries/workouts/$workoutId/stream');
+        expect(req.url.toString(),
+            contains('/timeseries/workouts/$workoutId/stream'));
         expect(req.method, 'GET');
         expect(req.headers['x-vital-api-key'], apiKey);
         return http.Response(
@@ -79,7 +84,8 @@ void main() {
         );
       });
 
-      final sut = WorkoutService.create(httpClient, '', apiKey);
+      final sut = WorkoutService.create(httpClient,
+          Uri.parse("https://example.com"), VitalInterceptor(false, apiKey));
       final response = await sut.getWorkoutStream(workoutId);
       final stream = response.body!;
       expect(stream.altitude.length, 0);

--- a/packages/vital_core/vital_core_android/android/build.gradle
+++ b/packages/vital_core/vital_core_android/android/build.gradle
@@ -3,7 +3,10 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.8.10'
+
+    // NOTE: Please update `packages/vital_core/vital_core/lib/services/utils/vital_interceptor.dart` as well.
     ext.vital_sdk_version = '1.0.0-beta.23'
+
     repositories {
         google()
         mavenCentral()

--- a/packages/vital_core/vital_core_android/android/src/main/kotlin/io/vital/VitalCorePlugin.kt
+++ b/packages/vital_core/vital_core_android/android/src/main/kotlin/io/vital/VitalCorePlugin.kt
@@ -205,6 +205,24 @@ class VitalCorePlugin : FlutterPlugin, MethodCallHandler {
                 }
             }
 
+            "getAccessToken" -> {
+                try {
+                    val accessToken = VitalClient.getAccessToken(context)
+                    result.success(accessToken)
+                } catch (e: Throwable) {
+                    reportError(e)
+                }
+            }
+
+            "refreshToken" -> {
+                try {
+                    VitalClient.refreshToken(context)
+                    result.success(null)
+                } catch (e: Throwable) {
+                    reportError(e)
+                }
+            }
+
             "clientStatus" -> {
                 VitalClient.getOrCreate(context)
                 // lowerCamelCase to match iOS.

--- a/packages/vital_core/vital_core_ios/ios/Classes/SwiftVitalCorePlugin.swift
+++ b/packages/vital_core/vital_core_ios/ios/Classes/SwiftVitalCorePlugin.swift
@@ -173,6 +173,22 @@ public class SwiftVitalCorePlugin: NSObject, FlutterPlugin {
         await VitalClient.shared.cleanUp()
         result(nil)
 
+      case "getAccessToken":
+        do {
+          let accessToken = try await VitalClient.getAccessToken()
+          result(accessToken)
+        } catch let error {
+          reportError(error)
+        }
+
+      case "refreshToken":
+        do {
+          try await VitalClient.refreshToken()
+          result(nil)
+        } catch let error {
+          reportError(error)
+        }
+
       case "clientStatus":
         var values = [String]()
         let status = VitalClient.status

--- a/packages/vital_core/vital_core_ios/ios/vital_core_ios.podspec
+++ b/packages/vital_core/vital_core_ios/ios/vital_core_ios.podspec
@@ -12,6 +12,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+
+  # NOTE: Please update `packages/vital_core/vital_core/lib/services/utils/vital_interceptor.dart` as well.
   s.dependency 'VitalCore', '~> 0.10.8'
   s.platform = :ios, '14.0'
 

--- a/packages/vital_core/vital_core_platform_interface/lib/src/vital_core_method_channel.dart
+++ b/packages/vital_core/vital_core_platform_interface/lib/src/vital_core_method_channel.dart
@@ -94,4 +94,16 @@ class VitalCoreMethodChannel extends VitalCorePlatform {
   Future<void> cleanUp() {
     return _channel.invokeMethod("cleanUp");
   }
+
+  @override
+  Future<String> getAccessToken() {
+    return _channel
+        .invokeMethod("getAccessToken")
+        .then((value) => value as String);
+  }
+
+  @override
+  Future<void> refreshToken() {
+    return _channel.invokeMethod("refreshToken");
+  }
 }

--- a/packages/vital_core/vital_core_platform_interface/lib/src/vital_core_platform.dart
+++ b/packages/vital_core/vital_core_platform_interface/lib/src/vital_core_platform.dart
@@ -56,4 +56,12 @@ class VitalCorePlatform extends PlatformInterface {
   Future<void> cleanUp() {
     throw UnimplementedError();
   }
+
+  Future<String> getAccessToken() {
+    throw UnimplementedError();
+  }
+
+  Future<void> refreshToken() {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
Extend `VitalClient` so that it can work with both API Keys and Vital Sign-In Token sign-ins.

* New initializer `VitalClient.forSignedInUser` that would create a VitalClient that would request a User JWT from the native iOS/Android SDK, and inject it as `Authorization` header.

* Example app - Signed In User screen: Add a button to create a Link token and print it to the log.