### PR TITLE
VIT-5547: Migrate VitalHealth.ask to use ActivityResultRegistry for Android 14 Permission Manager compatibility

### DIFF
--- a/example/android/app/src/main/kotlin/com/example/vital_flutter_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/example/vital_flutter_example/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.example.vital_flutter_example
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity: FlutterActivity() {
+class MainActivity: FlutterFragmentActivity() {
 }

--- a/packages/vital_health/vital_health_android/android/build.gradle
+++ b/packages/vital_health/vital_health_android/android/build.gradle
@@ -60,4 +60,8 @@ dependencies {
     implementation "com.github.tryVital.vital-android:VitalClient:$vital_sdk_version"
     implementation "com.github.tryVital.vital-android:VitalHealthConnect:$vital_sdk_version"
     implementation "androidx.health.connect:connect-client:$health_connect_version"
+
+    // Require at minimum 1.3.4 to workaround Fragment ActivityResultRegistry issue
+    // > java.lang.IllegalArgumentException: Can only use lower 16 bits for requestCode
+    implementation "androidx.fragment:fragment:1.3.4"
 }


### PR DESCRIPTION
Backport https://github.com/tryVital/vital-react-native/pull/74 to Flutter SDK. Health Connect permission flow only launches on Android 14 through the ActivityResultsRegistry-based APIs.

