### PR TITLE
Fix Android vital_health.ask interop response handling

### DIFF
--- a/example/lib/user/user_bloc.dart
+++ b/example/lib/user/user_bloc.dart
@@ -133,8 +133,9 @@ class UserBloc extends ChangeNotifier {
     }
   }
 
-  void askForHealthResources() {
-    vital_health.askForPermission([
+  void askForHealthResources() async {
+    vital_health.PermissionOutcome outcome =
+        await vital_health.askForPermission([
       vital_health.HealthResource.profile,
       vital_health.HealthResource.body,
       vital_health.HealthResource.activity,
@@ -150,6 +151,8 @@ class UserBloc extends ChangeNotifier {
       vital_health.HealthResourceWrite.caffeine,
       vital_health.HealthResourceWrite.mindfulSession
     ]);
+
+    Fimber.i("Ask Outcome: $outcome");
   }
 
   Future<void> sync() async {

--- a/packages/vital_health/vital_health_android/android/src/main/kotlin/io/vital/VitalHealthPlugin.kt
+++ b/packages/vital_health/vital_health_android/android/src/main/kotlin/io/vital/VitalHealthPlugin.kt
@@ -193,8 +193,23 @@ class VitalHealthPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
 
             if (continuation != null) {
                 taskScope.launch {
-                    result.await()
-                    continuation.second.success(null)
+                    val response = when (result.await()) {
+                        // Null = success
+                        is PermissionOutcome.Success -> null
+                        is PermissionOutcome.Failure -> JSONObject(
+                            mapOf(
+                                "code" to "failure",
+                                "message" to "",
+                            )
+                        ).toString()
+                        is PermissionOutcome.HealthConnectUnavailable -> JSONObject(
+                            mapOf(
+                                "code" to "healthKitNotAvailable",
+                                "message" to "Health Connect is not available"
+                            )
+                        ).toString()
+                    }
+                    continuation.second.success(response)
                 }
             }
         })


### PR DESCRIPTION
Mirror iOS interop, so that the three cases of `PermissionOutcome` are properly reported by Android interop.