### PR TITLE
CS1-142: vital_health should re-export ProcessedData types

### DIFF
--- a/example/lib/user/user_bloc.dart
+++ b/example/lib/user/user_bloc.dart
@@ -178,7 +178,7 @@ class UserBloc extends ChangeNotifier {
   }
 
   Future<void> read(vital_health.HealthResource healthResource) async {
-    final result = await vital_health.read(healthResource,
+    vital_health.ProcessedData? result = await vital_health.read(healthResource,
         DateTime.now().subtract(const Duration(days: 10)), DateTime.now());
 
     Fimber.i("Read $healthResource: $result");

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -26,13 +26,13 @@ packages:
     source: hosted
     version: "1.3.0"
   chopper:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: chopper
-      sha256: "5eeeec0feb99829b22fc6935c61296ad7e6467355ee13842921ec2a4bc849371"
+      sha256: d1457197abb29ee354889fda35a7ac2e752eb5a687562148afb1faa78a61e36d
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.7+1"
+    version: "7.1.1"
   clock:
     dependency: transitive
     description:
@@ -403,84 +403,84 @@ packages:
       path: "../packages/vital_core/vital_core"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_core_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_android"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_core_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_ios"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_core_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_platform_interface"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_devices:
     dependency: "direct main"
     description:
       path: "../packages/vital_devices/vital_devices"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_devices_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_android"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_devices_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_ios"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_devices_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_platform_interface"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_health:
     dependency: "direct main"
     description:
       path: "../packages/vital_health/vital_health"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_health_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_android"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_health_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_ios"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   vital_health_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_platform_interface"
       relative: true
     source: path
-    version: "3.0.9"
+    version: "3.1.0"
   web:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   vital_core: ^3.1.0
   vital_health: ^3.1.0
   vital_devices: ^3.1.0
+  chopper: ^7.1.1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/vital_core/vital_core/pubspec.lock
+++ b/packages/vital_core/vital_core/pubspec.lock
@@ -611,21 +611,21 @@ packages:
       path: "../vital_core_android"
       relative: true
     source: path
-    version: "3.0.7"
+    version: "3.1.0"
   vital_core_ios:
     dependency: "direct main"
     description:
       path: "../vital_core_ios"
       relative: true
     source: path
-    version: "3.0.7"
+    version: "3.1.0"
   vital_core_platform_interface:
     dependency: "direct main"
     description:
       path: "../vital_core_platform_interface"
       relative: true
     source: path
-    version: "3.0.7"
+    version: "3.1.0"
   watcher:
     dependency: transitive
     description:

--- a/packages/vital_health/vital_health/lib/vital_health.dart
+++ b/packages/vital_health/vital_health/lib/vital_health.dart
@@ -4,3 +4,4 @@ export 'package:vital_health_platform_interface/src/data/health_config.dart';
 export 'package:vital_health_platform_interface/src/data/permission_outcome.dart';
 export 'package:vital_health_platform_interface/src/data/sync_data.dart';
 export 'package:vital_health_platform_interface/src/health_resource.dart';
+export 'package:vital_health_platform_interface/src/data/processed_data/processed_data.dart';


### PR DESCRIPTION
`vital_health.read()` API returns a `ProcessedData` subclass. This is not reexported by vital_health at the moment.