### PR TITLE
CS1-158 Flutter SDK: Health syncStatus does not update

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -14,7 +14,7 @@ PODS:
   - vital_health_ios (0.0.10):
     - Flutter
     - VitalHealthKit (~> 0.10.11)
-  - VitalCore (0.10.11)
+  - VitalCore (0.10.12)
   - VitalDevices (0.10.11):
     - CombineCoreBluetooth (~> 0.3.1)
     - VitalCore (~> 0.10.11)
@@ -58,7 +58,7 @@ SPEC CHECKSUMS:
   vital_core_ios: 9cdab8d6bcc61e2fab720548fd21f6466975fdd8
   vital_devices_ios: c27f5f80a25c36e94075955dab4afc779f94703b
   vital_health_ios: 0e724b1cb4dd5f0b1544576e1407c28f2a104a3b
-  VitalCore: 6ec2c2df343522829d83425d5a86c5761fd8ee2c
+  VitalCore: 31401da4f5a1f600f6fc508ae63416ca272e98df
   VitalDevices: efb219648a60e91a31c060cd70e52bb1e5fbb117
   VitalHealthKit: a3b5881bd6fae0938e88080298559bd055921f25
 

--- a/example/lib/secrets.dart
+++ b/example/lib/secrets.dart
@@ -1,7 +1,7 @@
 import 'package:vital_core/vital_core.dart';
 
 // Replace this with your own API key
-const apiKey = 'sk_us_......';
+const apiKey = 'sk_us_o2nDlsPc5ZfUgUUhNy3xittlAnMMmjn_re4wAz4fC_s';
 
 const region = Region.us;
 const environment = Environment.sandbox;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -403,84 +403,84 @@ packages:
       path: "../packages/vital_core/vital_core"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_core_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_android"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_core_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_ios"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_core_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_platform_interface"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_devices:
     dependency: "direct main"
     description:
       path: "../packages/vital_devices/vital_devices"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_devices_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_android"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_devices_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_ios"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_devices_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_platform_interface"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_health:
     dependency: "direct main"
     description:
       path: "../packages/vital_health/vital_health"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_health_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_android"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_health_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_ios"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_health_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_platform_interface"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   web:
     dependency: transitive
     description:

--- a/packages/vital_core/vital_core/pubspec.lock
+++ b/packages/vital_core/vital_core/pubspec.lock
@@ -611,21 +611,21 @@ packages:
       path: "../vital_core_android"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_core_ios:
     dependency: "direct main"
     description:
       path: "../vital_core_ios"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   vital_core_platform_interface:
     dependency: "direct main"
     description:
       path: "../vital_core_platform_interface"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   watcher:
     dependency: transitive
     description:

--- a/packages/vital_health/vital_health/lib/health.dart
+++ b/packages/vital_health/vital_health/lib/health.dart
@@ -8,6 +8,8 @@ import 'package:vital_health_platform_interface/vital_health_platform_interface.
 // > https://dart.dev/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members
 // > AVOID defining a class that contains only static members
 
+/// Health Data sync status.
+/// Note that this stream does not replay any status already emitted.
 Stream<SyncStatus> get syncStatus => VitalHealthPlatform.instance.status;
 
 /// Android: Whether Health Connect is available on the current device.

--- a/packages/vital_health/vital_health_android/android/src/main/kotlin/io/vital/health/VitalHealthPlugin.kt
+++ b/packages/vital_health/vital_health_android/android/src/main/kotlin/io/vital/health/VitalHealthPlugin.kt
@@ -102,7 +102,7 @@ class VitalHealthPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
             } catch (e: Throwable) {
                 withContext(Dispatchers.Main) {
                     channel.invokeMethod(
-                        "unknown", listOf("failedSyncing")
+                        "status", listOf("failedSyncing")
                     )
                 }
             }

--- a/packages/vital_health/vital_health_android/lib/vital_health_android.dart
+++ b/packages/vital_health/vital_health_android/lib/vital_health_android.dart
@@ -13,10 +13,22 @@ const _channel = MethodChannel('vital_health_connect');
 
 class VitalHealthAndroid extends VitalHealthPlatform {
   static void registerWith() {
-    VitalHealthPlatform.instance = VitalHealthAndroid();
+    VitalHealthPlatform.instanceFactory = () => VitalHealthAndroid();
   }
 
   final _statusSubject = PublishSubject<SyncStatus>();
+
+  VitalHealthAndroid() : super() {
+    _channel.setMethodCallHandler((call) async {
+      switch (call.method) {
+        case "status":
+          {
+            _statusSubject
+                .add(mapArgumentsToStatus(call.arguments as List<dynamic>));
+          }
+      }
+    });
+  }
 
   @override
   Future<bool> isAvailable() async {
@@ -27,16 +39,6 @@ class VitalHealthAndroid extends VitalHealthPlatform {
   Future<void> configureClient(
       String apiKey, Region region, Environment environment) async {
     Fimber.d('Health Connect configure $apiKey, $region $environment');
-
-    _channel.setMethodCallHandler((call) async {
-      switch (call.method) {
-        case "status":
-          {
-            _statusSubject
-                .add(mapArgumentsToStatus(call.arguments as List<dynamic>));
-          }
-      }
-    });
 
     await _channel.invokeMethod('configureClient', <String, dynamic>{
       "apiKey": apiKey,

--- a/packages/vital_health/vital_health_ios/ios/Classes/SwiftVitalHealthKitPlugin.swift
+++ b/packages/vital_health/vital_health_ios/ios/Classes/SwiftVitalHealthKitPlugin.swift
@@ -279,14 +279,16 @@ public class SwiftVitalHealthKitPlugin: NSObject, FlutterPlugin {
 
   private func subscribeToStatus(){
     cancellable?.cancel()
-    cancellable = VitalHealthKitClient.shared.status.sink {[weak self] value in
-      guard self?.flutterRunning ?? false else {
-        return
-      }
+    cancellable = VitalHealthKitClient.shared.status
+      .receive(on: DispatchQueue.main)
+      .sink {[weak self] value in
+        guard self?.flutterRunning ?? false else {
+          return
+        }
 
-      self?.channel.invokeMethod("sendStatus", arguments: mapStatusToArguments(value))
+        self?.channel.invokeMethod("sendStatus", arguments: mapStatusToArguments(value))
+      }
     }
-  }
 }
 
 struct AnyEncodable: Encodable {

--- a/packages/vital_health/vital_health_platform_interface/lib/src/vital_health_platform.dart
+++ b/packages/vital_health/vital_health_platform_interface/lib/src/vital_health_platform.dart
@@ -7,14 +7,20 @@ class VitalHealthPlatform extends PlatformInterface {
 
   VitalHealthPlatform() : super(token: _token);
 
-  static VitalHealthPlatform _instance = VitalHealthPlatform();
+  static VitalHealthPlatform Function()? _instanceFactory = null;
+  static VitalHealthPlatform? _instance;
 
-  static set instance(VitalHealthPlatform instance) {
-    PlatformInterface.verify(instance, _token);
-    _instance = instance;
+  static set instanceFactory(VitalHealthPlatform Function() factory) {
+    _instanceFactory = factory;
   }
 
-  static VitalHealthPlatform get instance => _instance;
+  static VitalHealthPlatform get instance {
+    if (_instance == null) {
+      _instance = _instanceFactory!();
+      PlatformInterface.verify(_instance!, _token);
+    }
+    return _instance!;
+  }
 
   Stream<SyncStatus> get status =>
       throw UnimplementedError('status() has not been implemented.');


### PR DESCRIPTION
* iOS Plugin should send status on main thread.

* Method channel handler on the Flutter side should be set unconditionally, rather than only when `configureHealth` is called.