### PR TITLE
DEV-290: Remove dependency on RxDart

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -280,14 +280,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.5"
-  rxdart:
-    dependency: transitive
-    description:
-      name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.27.7"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -427,84 +419,84 @@ packages:
       path: "../packages/vital_core/vital_core"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_core_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_android"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_core_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_ios"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_core_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_core/vital_core_platform_interface"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_devices:
     dependency: "direct main"
     description:
       path: "../packages/vital_devices/vital_devices"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_devices_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_android"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_devices_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_ios"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_devices_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_devices/vital_devices_platform_interface"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_health:
     dependency: "direct main"
     description:
       path: "../packages/vital_health/vital_health"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_health_android:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_android"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_health_ios:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_ios"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vital_health_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../packages/vital_health/vital_health_platform_interface"
       relative: true
     source: path
-    version: "4.3.3"
+    version: "4.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/packages/vital_core/vital_core/pubspec.lock
+++ b/packages/vital_core/vital_core/pubspec.lock
@@ -635,21 +635,21 @@ packages:
       path: "../vital_core_android"
       relative: true
     source: path
-    version: "4.3.2"
+    version: "4.4.2"
   vital_core_ios:
     dependency: "direct main"
     description:
       path: "../vital_core_ios"
       relative: true
     source: path
-    version: "4.3.2"
+    version: "4.4.2"
   vital_core_platform_interface:
     dependency: "direct main"
     description:
       path: "../vital_core_platform_interface"
       relative: true
     source: path
-    version: "4.3.2"
+    version: "4.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/packages/vital_devices/vital_devices/pubspec.yaml
+++ b/packages/vital_devices/vital_devices/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   flutter:
     sdk: flutter
   fimber: ^0.6.6
-  rxdart: ^0.27.3
   vital_core: ^4.4.2
   vital_devices_platform_interface: ^4.4.2
   vital_devices_android: ^4.4.2

--- a/packages/vital_devices/vital_devices_platform_interface/pubspec.yaml
+++ b/packages/vital_devices/vital_devices_platform_interface/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   flutter:
     sdk: flutter
   permission_handler: ">=10.2.0"
-  rxdart: ^0.27.3
   fimber: ^0.6.6
   plugin_platform_interface: ^2.1.0
   vital_core: ^4.4.2

--- a/packages/vital_health/vital_health_android/lib/vital_health_android.dart
+++ b/packages/vital_health/vital_health_android/lib/vital_health_android.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import 'package:fimber/fimber.dart';
 import 'package:flutter/services.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:vital_core/exceptions.dart';
 import 'package:vital_core/samples.dart';
 import 'package:vital_core/vital_core.dart';
@@ -16,14 +15,15 @@ class VitalHealthAndroid extends VitalHealthPlatform {
     VitalHealthPlatform.instanceFactory = () => VitalHealthAndroid();
   }
 
-  final _statusSubject = PublishSubject<SyncStatus>();
+  final _statusStream = StreamController<SyncStatus>();
+  late final _statusStreamBroadcast = _statusStream.stream.asBroadcastStream();
 
   VitalHealthAndroid() : super() {
     _channel.setMethodCallHandler((call) async {
       switch (call.method) {
         case "status":
           {
-            _statusSubject
+            _statusStream
                 .add(mapArgumentsToStatus(call.arguments as List<dynamic>));
           }
       }
@@ -215,7 +215,7 @@ class VitalHealthAndroid extends VitalHealthPlatform {
   }
 
   @override
-  Stream<SyncStatus> get status => _statusSubject.stream;
+  Stream<SyncStatus> get status => _statusStreamBroadcast;
 }
 
 ProcessedData _mapJsonToProcessedData(

--- a/packages/vital_health/vital_health_android/pubspec.yaml
+++ b/packages/vital_health/vital_health_android/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.0
   fimber: ^0.6.6
-  rxdart: ^0.27.1
   vital_core: ^4.4.2
   vital_health_platform_interface: ^4.4.2
 dev_dependencies:


### PR DESCRIPTION
We no longer use RxDart at any capacity. Stop declaring it as a dependency.